### PR TITLE
Dropped support for Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ perl:
     - "5.24"
     - "5.22"
     - "5.20"
-    - "5.18"
     - "5.16"
 before_install:
     - eval $(curl https://travis-perl.github.io/init) --auto


### PR DESCRIPTION
After dropping support for Ubuntu 14.04, none of the supported platforms use Perl 5.18.