### PR TITLE
Add headers to every line of multiline log entries

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -444,10 +444,16 @@ sub run {
                     if ( $self->show_testcase ) {
                         $prefix .= sprintf "%-14s ", $entry->testcase;
                     }
+                    $prefix .= $entry->tag;
 
                     my $message = $entry->string;
-                    $message =~ s/^([A-Z0-9]+:)*//;
-                    printf "%s%s\n", $prefix, $message;
+                    $message =~ s/^[A-Z0-9:]+//;    # strip MODULE:TAG, they're coming in $prefix instead
+                    my @lines = split /\n/, $message;
+
+                    printf "%s%s %s\n", $prefix, ' ', shift @lines;
+                    for my $line ( @lines ) {
+                        printf "%s%s %s\n", $prefix, '>', $line;
+                    }
                 }
             } ## end if ( $numeric{ uc $entry...})
             if ( $self->stop_level and $numeric{ uc $entry->level } >= $numeric{ $self->stop_level } ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -437,16 +437,17 @@ sub run {
                     # Don't do anything
                 }
                 else {
-                    my $str = sprintf "%7.2f %-9s ", $entry->timestamp, $entry->level;
+                    my $prefix = sprintf "%7.2f %-9s ", $entry->timestamp, $entry->level;
                     if ( $self->show_module ) {
-                        $str.= sprintf "%-12s ", $entry->module;
+                        $prefix .= sprintf "%-12s ", $entry->module;
                     }
                     if ( $self->show_testcase ) {
-                        $str.= sprintf "%-14s ", $entry->testcase;
+                        $prefix .= sprintf "%-14s ", $entry->testcase;
                     }
-                    my $entry_str = sprintf "%s", $entry->string;
-                    $entry_str =~ s/^([A-Z0-9]+:)*//;
-                    printf "%s%s\n", $str, $entry_str;
+
+                    my $message = $entry->string;
+                    $message =~ s/^([A-Z0-9]+:)*//;
+                    printf "%s%s\n", $prefix, $message;
                 }
             } ## end if ( $numeric{ uc $entry...})
             if ( $self->stop_level and $numeric{ uc $entry->level } >= $numeric{ $self->stop_level } ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -447,7 +447,7 @@ sub run {
                     $prefix .= $entry->tag;
 
                     my $message = $entry->string;
-                    $message =~ s/^[A-Z0-9:]+//;    # strip MODULE:TAG, they're coming in $prefix instead
+                    $message =~ s/^[A-Z0-9:_]+//;    # strip MODULE:TAG, they're coming in $prefix instead
                     my @lines = split /\n/, $message;
 
                     printf "%s%s %s\n", $prefix, ' ', shift @lines;


### PR DESCRIPTION
Add headers to all of the lines in `--raw` mode. To tell where new entries begin I added a marker character right after MODULE:TAG. The first line of an entry is marked with an extra SPACE character. The following lines are marked with a '>' character.

When you have headers on all lines you can filter the logs with better precision using grep.

**Edit:** I removed the reference to #111 as this PR solves a different problem.