### PR TITLE
Centos installation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,8 +16,6 @@ tests_recursive( 't' );
 
 configure_requires( 'Locale::Msgfmt' => 0.15, );
 
-build_requires( 'Test::More' => 0, );
-
 requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -38,6 +38,18 @@ This instruction covers the following operating systems:
 
 ### 1. CentOS
 
+Install binary dependencies:
+
+```sh
+sudo yum install perl-JSON-XS
+```
+
+Install dependencies from CPAN:
+
+```sh
+sudo cpanm Locale::Msgfmt Locale::TextDomain MooseX::Getopt Text::Reflow
+```
+
 Install Zonemaster::CLI 
 
 ```sh


### PR DESCRIPTION
Fixes #117.

Also cleans up a useless explicit dependency on a core module.