### PR TITLE
Better performance when running specified test. Function to exclude tests

### DIFF
--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -141,6 +141,13 @@ module. The specified method will be called with a zone object as its single
 argument. It's up to the user to make sure that that is the kind of argument
 the method expects.
 
+=item --exclude_test=MODULE, --exclude_test=MODULE/METHOD
+
+Run all tests except the specified tests. You can either give the name of a 
+testing module, in which case that module will be ignored, or you can give
+the name of a module followed by a slash and the name of a method in that
+module. The specified method will be ignored.
+
 =item --stop_level=LEVEL
 
 As soon as a message of the given level or higher is logged, terminate the

--- a/share/sv.po
+++ b/share/sv.po
@@ -54,6 +54,9 @@ msgstr "Istället för att köra tester, skriv ut en lista med alla tillgänglig
 msgid "Specify test to run. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a \"/\" character (Example: \"Basic/basic1\"). The method specified must be one that takes a zone object as its single argument. This switch can be repeated"
 msgstr "Specificera tester att köra. Skall vara antingen namnet på en testmodul, eller namnet på en modul och namnet på en testmetod i den modulen separerade med ett snedstreck (exempel: \"Basic/basic1\"). Den utpekade metoden måste vara en som tar enbart ett zon-objekt som argument. Den här flaggan kan anges flera gånger."
 
+msgid "Specify test to skip. Should be the name of a module and the name of a method in that module separated by a \"/\" character (Example: \"Basic/basic1\"). The method specified must be one that takes a zone object as its single argument. This switch can be repeated."
+msgstr "Specificera tester att hoppa över. Skall vara antingen namnet på en testmodul, eller namnet på en modul och namnet på en testmetod i den modulen separerade med ett snedstreck (exempel: \"Basic/basic1\"). Den utpekade metoden måste vara en som tar enbart ett zon-objekt som argument. Den här flaggan kan anges flera gånger."
+
 msgid "As soon as a message at this level or higher is logged, execution will stop"
 msgstr "Avsluta testkörningen så snart ett meddelande med denna nivå eller högre registreras."
 


### PR DESCRIPTION
Sometimes it is desired to skip some tests, for example in an Anycast DNS setup where all servers are in the same AS.

When running multiple test with --test, the performance is not that good since a Zonemaster::Engine->zone( $domain ) object is created for each specified test. This fixes this by only creating this object once
