### PR TITLE
Update translation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cover_db/
 blib/
 inc/
 share/locale/
+share/*.mo
 .lwpcookies
 .last_cover_stats
 nytprof.out
@@ -18,3 +19,4 @@ pm_to_blib
 Zonemaster-CLI-*
 Zonemaster-CLI-*.tar.gz
 *.bak
+share/Zonemaster-CLI.pot

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,6 @@ resources(
 
 tests_recursive( 't' );
 
-configure_requires( 'Locale::Msgfmt' => 0.15, );
-
 requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -397,7 +397,7 @@ sub run {
                     }
 
                     if ( $self->show_level ) {
-                        printf "%-9s ", __( $entry->level );
+                        printf "%-9s ", translate_severity( $entry->level );
                     }
 
                     if ( $self->show_module ) {
@@ -515,7 +515,7 @@ sub run {
         say __( "\n\n   Level\tNumber of log entries" );
         say "   =====\t=====================";
         foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
-            printf __( "%8s\t%5d entries.\n" ), __( $level ), $counter{$level};
+            printf __( "%8s\t%5d entries.\n" ), translate_severity( $level ), $counter{$level};
         }
     }
 
@@ -674,6 +674,31 @@ sub do_dump_profile {
     print $json->encode( Zonemaster::Engine::Profile->effective->{ q{profile} } );
 
     exit;
+}
+
+sub translate_severity {
+    my $severity = shift;
+    if ( $severity eq "DEBUG" ) {
+        return __( "DEBUG" );
+    }
+    elsif ( $severity eq "INFO" ) {
+        return __( "INFO" );
+    }
+    elsif ( $severity eq "NOTICE" ) {
+        return __( "NOTICE" );
+    }
+    elsif ( $severity eq "WARNING" ) {
+        return __( "WARNING" );
+    }
+    elsif ( $severity eq "ERROR" ) {
+        return __( "ERROR" );
+    }
+    elsif ( $severity eq "CRITICAL" ) {
+        return __( "CRITICAL" );
+    }
+    else {
+        return $severity;
+    }
 }
 
 1;

--- a/share/Makefile
+++ b/share/Makefile
@@ -1,8 +1,36 @@
-POFILES = $(wildcard *.po)
-MOFILES := $(POFILES:.po=.mo)
+.POSIX:
+.SUFFIXES: .po .mo
+.PHONY: all dist touch-po update-po extract-pot
 
-%.mo: %.po
-	@mkdir -p locale/$*/LC_MESSAGES
-	@perl -e 'use Locale::Msgfmt; msgfmt({in => $$ARGV[0], out => $$ARGV[1]});' $< locale/$*/LC_MESSAGES/Zonemaster-CLI.mo
+DISTNAME = Zonemaster-CLI
+POFILES != echo *.po
+MOFILES := $(POFILES:%.po=%.mo)
+POTFILE = $(DISTNAME).pot
+PMFILES != find ../lib -type f -name '*.pm' | sort
 
-all: ${MOFILES}
+all: $(MOFILES)
+	@echo
+	@echo Remember to make sure all of the above names are in the
+	@echo MANIFEST file, or they will not be installed.
+	@echo
+
+touch-po:
+	@touch $(POTFILE) $(POFILES)
+
+update-po: extract-pot $(POFILES)
+
+extract-pot:
+	@xgettext --output $(POTFILE) --sort-by-file --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
+
+$(POTFILE): extract-pot
+
+%.po: $(POTFILE)
+	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
+
+.po.mo:
+	@msgfmt -o $@ $<
+	@mkdir -p locale/`basename $@ .mo`/LC_MESSAGES
+	@ln -vf $@ locale/`basename $@ .mo`/LC_MESSAGES/$(DISTNAME).mo
+
+show-fuzzy:
+	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done


### PR DESCRIPTION
This PR enables the adoption in CLI of the translation workflow we use in Engine.
This will affect the format of the PO files making for a large initial diff. That initial update is excluded from this PR because the PO files are currently not up to date.

Fixes #132. Fixes #147.