### PR TITLE
Skip MO files directly under share

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -6,6 +6,8 @@
 \.tar\.gz$
 \.bak$
 \.po$
+# Skip MO files directly under share
+^share/[^/]*\.mo$
 
 #!start included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.


### PR DESCRIPTION
PR #151 updated the way the MO files are generated. Now two copies are created and the one directly under /share should be skipped. PR #151 missed to include a SKIP statement in MANIFEST.SKIP, which is done here, modeled after the statement in Zonemster-Engine.