### PR TITLE
Remove useless calls to Z::E::Translator::data

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -366,13 +366,11 @@ sub run {
     my $translator;
     $translator = Zonemaster::Engine::Translator->new unless ( $self->raw or $self->json or $self->json_stream );
     $translator->locale( $self->locale ) if $translator and $self->locale;
-    eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 
     my $json_translator;
     if ( $self->json_translate ) {
         $json_translator = Zonemaster::Engine::Translator->new;
         $json_translator->locale( $self->locale ) if $self->locale;
-        eval { $json_translator->data };
     }
 
     if ( $self->restore ) {


### PR DESCRIPTION
The Z::E::Translator::data is neither used by zonemaster-cli nor by Zonemaster::Engine itself so there's no need for zonemaster-cli to load it.