### PR TITLE
Updated MANIFEST.SKIP

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -8,6 +8,7 @@
 \.po$
 # Skip MO files directly under share
 ^share/[^/]*\.mo$
+^share/Zonemaster-CLI.pot$
 
 #!start included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.


### PR DESCRIPTION
share/Zonemaster-CLI.pot is not included in distribution and should be skipped.