### PR TITLE
Avoid updating PO files for clean repo

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,11 +39,11 @@ sub MY::postamble {
         # Make FreeBSD use gmake for share
         return "GMAKE ?= \"gmake\"\n"
             . "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(GMAKE) all\n";
+            . "\tcd share && \$(GMAKE) touch-po all\n";
     } else {
         # Here Linux and GNU Make is assumed
         return "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(MAKE) all\n";
+            . "\tcd share && \$(MAKE) touch-po all\n";
     };
 };
 


### PR DESCRIPTION
When I run `perl Makefile.PL` on a fresh repository in preparation for running `make dist`, the PO files are updated with fuzzy translations. Engine does not have this problem. This PR adopts the solution from Engine, making sure that the PO files are not updated when running Makefile.PL.