### PR TITLE
Update dependencies installation on CentOS

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -46,8 +46,18 @@ This instruction covers the following operating systems:
 2) Install dependencies from CPAN:
 
    ```sh
-   sudo cpanm Net::Interface Text::Reflow
+   sudo cpanm Text::Reflow
+   curl -O https://cpan.metacpan.org/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz
+   tar xf Net-Interface-1.016.tar.gz
+   cd Net-Interface-1.016
+   ./configure
+   perl -I. Makefile.PL
+   make
+   sudo make install
    ```
+
+   > **Note:** We only recommend installing Net::Interface this way because of
+   > compilation errors when using `cpanm` on CentOS 8.
 
 3) Install Zonemaster::CLI 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -45,19 +45,24 @@ This instruction covers the following operating systems:
 
 2) Install dependencies from CPAN:
 
-   ```sh
-   sudo cpanm Text::Reflow
-   curl -O https://cpan.metacpan.org/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz
-   tar xf Net-Interface-1.016.tar.gz
-   cd Net-Interface-1.016
-   ./configure
-   perl -I. Makefile.PL
-   make
-   sudo make install
-   ```
+   * CentOS 7:
 
-   > **Note:** We only recommend installing Net::Interface this way because of
-   > compilation errors when using `cpanm` on CentOS 8.
+     ```sh
+     sudo cpanm Net::Interface Text::Reflow
+     ```
+
+   * CentOS 8:
+
+     ```sh
+     sudo cpanm Text::Reflow
+     curl -O https://cpan.metacpan.org/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz
+     tar xf Net-Interface-1.016.tar.gz
+     cd Net-Interface-1.016
+     ./configure
+     perl -I. Makefile.PL
+     make
+     sudo make install
+     ```
 
 3) Install Zonemaster::CLI 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -40,13 +40,13 @@ This instruction covers the following operating systems:
 1) Install binary dependencies:
 
    ```sh
-   sudo yum install perl-JSON-XS
+   sudo yum install perl-JSON-XS perl-MooseX-Getopt
    ```
 
 2) Install dependencies from CPAN:
 
    ```sh
-   sudo cpanm Locale::Msgfmt Locale::TextDomain MooseX::Getopt Text::Reflow Net::Interface
+   sudo cpanm Net::Interface Text::Reflow
    ```
 
 3) Install Zonemaster::CLI 


### PR DESCRIPTION
* Replace MooseX::Getopt with perl-MooseX-Getopt
* Remove Locale::MsgFmt (not used)
* Remove Locale::TextDomain (use the same one as Engine)
* Work around compolation errors on CentOS 8