### PR TITLE
Prepares for release of v2021.1 (CLI)

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,8 +7,8 @@ v3.1.0 2021-05-28 (public release version)
 
  [Fixes]
  - Updates the installation instructions (#193, #191)
- - Updates translations (#204, #201, #205, #200, #205,
-   #200, #207, #202)
+ - Updates translations (#204, #201, #205, #200,
+   #207, #202)
 
 
 v3.0.4 2021-02-10 (public release version)

--- a/Changes
+++ b/Changes
@@ -1,5 +1,15 @@
 Release history for Zonemaster component Zonemaster-CLI 
 
+v3.1.0 2021-05-28 (public release version)
+
+ [Features]
+ - Adds Finnish translation (PO file) (#192, #191)
+
+ [Fixes]
+ - Updates the installation instructions (#193, #191)
+ - Updates translations (#204, #201, #205, #200)
+
+
 v3.0.4 2021-02-10 (public release version)
 
  [Features]

--- a/Changes
+++ b/Changes
@@ -7,7 +7,8 @@ v3.1.0 2021-05-28 (public release version)
 
  [Fixes]
  - Updates the installation instructions (#193, #191)
- - Updates translations (#204, #201, #205, #200)
+ - Updates translations (#204, #201, #205, #200, #205,
+   #200, #207, #202)
 
 
 v3.0.4 2021-02-10 (public release version)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,8 +23,8 @@ requires(
     'Net::Interface'     => 0,
     'MooseX::Getopt'     => 0,
     'Text::Reflow'       => 0,
-    'Zonemaster::Engine' => 4.001,
-    'Zonemaster::LDNS'   => 2.001,
+    'Zonemaster::Engine' => 4.002,
+    'Zonemaster::LDNS'   => 2.002,
 );
 
 # Make all platforms include inc/Module/Install/External.pm

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -11,7 +11,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v3.0.4" );
+use version; our $VERSION = version->declare( "v3.1.0" );
 
 use Locale::TextDomain 'Zonemaster-CLI';
 use Moose;


### PR DESCRIPTION
Updates:
* CLI.pm with new version (v3.1.0)
* Changes
* Makefile.PL (updated dependency)

~~This PR assumes that #205 will be merged before release.~~ DONE.

~~Travis will complain until https://github.com/zonemaster/zonemaster-engine/pull/924 is merged.~~ No, Travis logs

> Warning: prerequisite Zonemaster::Engine 4.002 not found. We have v4.1.1.

but it does not fail. With Github actions we get a failure.
