### PR TITLE
shorter output when option is incorrect

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -288,8 +288,8 @@ sub run {
     my %counter;
     my $printed_something;
 
-    if ( $self->extra_argv ) {
-        print "Unknown option: ", join q{ }, @{$self->extra_argv}, "\n";
+    if ( grep /^-/, @{ $self->extra_argv } ) {
+        print "Unknown option: ", join( q{ }, grep /^-/, @{ $self->extra_argv } ), "\n";
         print "Run \"zonemaster-cli -h\" to get the valid options\n";
         exit;
     }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -11,11 +11,11 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v3.3.0" );
+use version; our $VERSION = version->declare( "v3.4.0" );
 
 use Locale::TextDomain 'Zonemaster-CLI';
 use Moose;
-with 'MooseX::Getopt';
+with 'MooseX::Getopt::GLD' => { getopt_conf => [ 'pass_through' ] };
 
 use Zonemaster::Engine;
 use Zonemaster::Engine::Logger::Entry;
@@ -287,6 +287,12 @@ sub run {
     my @accumulator;
     my %counter;
     my $printed_something;
+
+    if ( $self->extra_argv ) {
+        print "Unknown option: ", join q{ }, @{$self->extra_argv}, "\n";
+        print "Run \"zonemaster-cli -h\" to get the valid options\n";
+        exit;
+    }
 
     if ( $self->locale ) {
         undef $ENV{LANGUAGE};


### PR DESCRIPTION
## Purpose

This PR does no longer display full usage in case of incorrect option

## Context

Fixes zonemaster/zonemaster-cli#160

## Changes

Add 'pass_through' option to MooseX::Getopt::GLD  prevents print of a systematic 'usage'.

## How to test this PR

use invalid option(s), the output will look like

> zonemaster-cli --jljlkfg --list_tests
Unknown option: --jljlkfg 
Run "zonemaster-cli -h" to get the valid options

