### PR TITLE
Adds information on CLI on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,57 @@
-Zonemaster CLI
-==============
-[![Build Status](https://travis-ci.org/zonemaster/zonemaster-engine.svg?branch=master)](https://travis-ci.org/zonemaster/zonemaster-engine)
-[![CPAN version](https://badge.fury.io/pl/Zonemaster-CLI.svg)](https://metacpan.org/pod/Zonemaster::CLI)
+# Zonemaster-CLI
 
-### Purpose
 
-This Git repository is one of the components of the Zonemaster software and contains the source for the Zonemaster CLI utility.
+## Purpose
+
+This Git repository is one of the components of the Zonemaster software and
+contains the source for the Zonemaster-CLI utility.
 
 For an overview of the Zonemaster software, please see the
 [Zonemaster repository].
 
+
 ## Prerequisite
 
-Before you install the Zonemaster CLI utility, you need the
-Zonemaster Engine test framework installed. Please see the
+Before you install the Zonemaster-CLI utility, you need the Zonemaster-Engine
+test framework installed. Please see the
 [Zonemaster Engine installation instructions]
 
-Installation
-============
 
-Installation instructions for the CLI
-[installation] document.
+## Installation
+
+For installation, see the [installation] document.
 
 
-### Configuration 
+## Configuration
 
 This repository does not need any specific configuration.
 
 
-### Docker
+## Docker
 
-To build a local image for Zonemaster CLI you need a [local Zonemaster Engine
-base image].
+Zonemaster-CLI is available on [Docker Hub], and can be run without any
+installation. See [USING] Zonemaster-CLI for how to run it on Docker.
 
-Build a new local base image:
+To build your own Docker image, see [Create Docker Image] documentation.
 
-```sh
-make all dist docker-build
-```
 
-Tag the local base image with the current version number:
-
-```sh
-make docker-tag-version
-```
-
-Tag the local base image as the latest version:
-
-```sh
-make docker-tag-latest
-```
-
-Test a zone using the local base image:
-
-```sh
-docker run --rm zonemtaster/cli:local zonemaster.net
-```
-
-### Documentation
+## Documentation
 
 Other than the installation documentation, no specific documentation is needed.
 The [USING] document provides an overview on how to use the CLI.
 
 
-### Participation, Contact and Bug reporting
+## Participation, Contact and Bug reporting
 
 For participation, contact and bug reporting, please see the main
 [Zonemaster README].
 
 
-License
-=======
-
-The software is released under the 2-clause BSD license. See separate LICENSE file.
-
-
+[Create Docker Image]:                            https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Hub]:                                     https://hub.docker.com/u/zonemaster
 [Installation]:                                   docs/Installation.md
 [USING]:                                          USING.md
 [Zonemaster Engine installation instructions]:    https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md
-[Zonemaster repository]:                          https://github.com/zonemaster/zonemaster
 [Zonemaster README]:                              https://github.com/zonemaster/zonemaster/blob/master/README.md
-[Local Zonemaster Engine base image]:             https://github.com/zonemaster/zonemaster/blob/master/README.md#docker
+[Zonemaster repository]:                          https://github.com/zonemaster/zonemaster
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For participation, contact and bug reporting, please see the main
 [Zonemaster README].
 
 
-[Docker Image Creation]                           https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Image Creation]:                          https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
 [Docker Hub]:                                     https://hub.docker.com/u/zonemaster
 [Installation]:                                   docs/Installation.md
 [USING]:                                          USING.md

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ This repository does not need any specific configuration.
 
 ## Docker
 
-Zonemaster-CLI is available on [Docker Hub], and can be run without any
-installation. See [USING] Zonemaster-CLI for how to run it on Docker.
+Zonemaster-CLI is available on [Docker Hub], and can be conveniently downloaded
+and run without any installation. See [USING] Zonemaster-CLI for how to run
+Zonemaster-CLI on Docker.
 
-To build your own Docker image, see [Create Docker Image] documentation.
+To build your own Docker image, see the [Docker Image Creation] documentation.
 
 
 ## Documentation
@@ -47,7 +48,7 @@ For participation, contact and bug reporting, please see the main
 [Zonemaster README].
 
 
-[Create Docker Image]:                            https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Image Creation]                           https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
 [Docker Hub]:                                     https://hub.docker.com/u/zonemaster
 [Installation]:                                   docs/Installation.md
 [USING]:                                          USING.md

--- a/USING.md
+++ b/USING.md
@@ -131,6 +131,17 @@ created. E.g.
 docker run -e LC_ALL=da -t --rm zonemaster/cli zonemaster.net
 ```
 
+If environment variable `LC_ALL` is set in the local shell with the correct
+"LANG" or with the equivalent "LOCALE" in from next section, then the following
+command will export `LC_ALL` with the that value to the docker container.
+```sh
+docker run -e LC_ALL -t --rm zonemaster/cli zonemaster.net
+```
+
+Environment vaiables `LANG` and `LC_MESSAGES` can be used in the same way as
+`LC_ALL`.
+
+
 ### In local installation
 
 By default all messages are in the language set in the local environment (if
@@ -167,9 +178,6 @@ users.
 
 If you only want to run a specific test case rather than the whole suite of
 tests, you can do that as well. E.g. test only test case [Connectivity03]:
-
-[Connectivity03]:  https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Connectivity-TP/connectivity03.md
-
 ```sh
 zonemaster-cli --test Connectivity/connectivity03 example.com
 ```
@@ -210,7 +218,9 @@ record, but keep the NS records from the parent by only specifying the
 DS record and no NS records on the command line.
 
 
+[Connectivity03]:                  https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Connectivity-TP/connectivity03.md
 [Get started]:                     https://www.docker.com/get-started
 [Installation instruction]:        docs/Installation.md
 [Severity Level Definitions]:      https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [Translation]:                     #Translation
+

--- a/USING.md
+++ b/USING.md
@@ -18,9 +18,13 @@ meets one of the following requirements:
 
 ### Using Docker
 
-To run Zonemaster-CLI on docker you have to make sure that Docker is installed.
-Instructions for installation are found on Docker [get started] page. When
-Docker has been installed, no more installation is needed to run
+To run Zonemaster-CLI on Docker you have to make sure that Docker is installed
+on the computer and that you can run Docker on it.
+* Instructions for installation are found on Docker [get started] page.
+* Run the command `docker ps` on the command line to verify that you can run
+  Docker on the computer.
+
+When Docker has been correctly installed, no more installation is needed to run
 `zonemaster-cli`. Just follow the examples below.
 
 ### Local installation
@@ -44,7 +48,7 @@ With local installation:
 zonemaster-cli zonemaster.net
 ```
 
-The output comes continously as the tests are performed.
+The output comes continuously as the tests are performed.
 ```
 Seconds Level     Message
 ======= ========= =======
@@ -73,10 +77,10 @@ zonemaster-cli zonemaster.net --no-ipv6 --show-testcase --locale=da_DK.UTF-8
 ```
 
 The difference between running `zonemaster-cli` on Docker or local installation
-is invocation string, `docker run -t --rm zonemaster/cli` vs. `zonemaster-cli`.
-To simplify this document, from now on the short `zonemaster-cli` will be used
-and for Docker the long string will be assumed. To simplify repeated invocation
-on Docker an alias can be created for the shell.
+is the invocation string, `docker run -t --rm zonemaster/cli` vs.
+`zonemaster-cli`. To simplify this document, from now on the shorter
+`zonemaster-cli` will be used and for Docker the longer string will be assumed.
+To simplify repeated invocation on Docker an alias can be created for the shell.
 
 To see all available command line options, use the `--help` command.
 
@@ -92,9 +96,9 @@ To change the level of reporting you can use a command line option, e.g
 `--level=INFO` includes level INFO and higher in the report. See
 "[Severity Level Definitions]" for more information on the levels.
 
-The default level reporting is in plain English (or some other language), but
-other output formats are also available with options `--raw` and `json`
-respectively.
+By default the output is formatted as plain text in English (or some other
+language), but other more "technical" output formats are also available with
+options `--raw` and `json`, respectively.
 
 
 ## Translation
@@ -150,7 +154,9 @@ docker run -t --rm zonemaster/cli zonemaster.net --locale=da_DK.UTF-8
 ```
 
 If the environment variable `LANGUAGE` is set with correct LOCALE then no option
-is needed, e.g. `LANGUAGE=da_DK.UTF-8`.
+is needed, e.g. `LANGUAGE=da_DK.UTF-8`. `zonemaster-cli` also respects `LC_ALL`,
+`LC_MESSAGES` and `LANG`. `LANGUAGE` takes precedence over the other, and then
+the order is `LC_ALL`, `LC_MESSAGES` and last `LANG`.
 
 ## Advanced use
 
@@ -184,7 +190,7 @@ zonemaster-cli --list_tests
 Before you do any delegation change at the parent, either changing the NS
 records, glue address records or DS records, you might want to perform a
 check of your new child zone configuration so that everything you plan to
-change is in order. Zonemaster can do this for your. All you have to do
+change is in order. Zonemaster can do this for you. All you have to do
 is give Zonemaster all the parent data you plan to have for your new
 configuration. Any DNS lookups going for the parent will instead be
 answered by the data you entered. E.g.

--- a/USING.md
+++ b/USING.md
@@ -1,116 +1,210 @@
-## Using the CLI
+# Using the CLI
 
-### Invoking the command line tool
+## Table of contents
+* [Docker or local installation](#Docker-or-local-installation)
+* [Invoking the command line tool](#Invoking-the-command-line-tool)
+* [Test reports](#Test-reports)
+* [Translation]
+* [Advanced use](#Advanced-use)
 
-The most basic use of the `zonemaster-cli` command is to just test a domain
-like this:
 
-    $ zonemaster-cli example.com
+## Docker or local installation
+
+The `zonemaster-cli` tool can be run from the command line of any computer that
+meets one of the following requirements:
+
+* Docker is installed on the computer, or
+* Zonemaster-CLI has been installed on the computer.
+
+### Using Docker
+
+To run Zonemaster-CLI on docker you have to make sure that Docker is installed.
+Instructions for installation are found on Docker [get started] page. When
+Docker has been installed, no more installation is needed to run
+`zonemaster-cli`. Just follow the examples below.
+
+### Local installation
+
+To have an local installation of Zonemaster-CLI follow the
+[installation instruction]. When installed, the examples below can be followed.
+
+
+## Invoking the command line tool
+
+The most basic use of the `zonemaster-cli` command is to just test a domain, e.g.
+"zonemaster.net".
+
+With Docker:
+```sh
+docker run -t --rm zonemaster/cli zonemaster.net
+```
+
+With local installation:
+```sh
+zonemaster-cli zonemaster.net
+```
 
 The output comes continously as the tests are performed.
+```
+Seconds Level     Message
+======= ========= =======
+  21.39 WARNING   The DNSKEY with tag 54636 uses an algorithm number 5 (RSA/SHA1) which is not recommended to be used.
+  21.80 WARNING   DNSKEY with tag 26280 and using algorithm 5 (RSA/SHA1) has a size (1024) smaller than the recommended one (2048).
+  23.61 NOTICE    SOA 'refresh' value (10800) is less than the recommended one (14400).
+```
 
-    Seconds Level     Message
-    ======= ========= =======
-       1.16 NOTICE    No illegal characters in the domain name (example.com).
-       2.01 WARNING   SOA 'refresh' value (10800) is less than the recommended one (14400).
-      13.86 CRITICAL  All nameservers are in the same AS (12345).
-      13.87 NOTICE    123.456.789.0 returned no DS records for example.com.
+The test and output can be modified with different options:
 
-If your machine is for some reason not configured for use with IPv6 you
-want to disable the use of IPv6 with the `--no-ipv6` option. If you want
-to see how your domain is configured to be used with no IPv4 available
-for the client there is also the `--no-ipv4` option - however, both cannot
-be used at the same time.
+* If your machine is for some reason not configured for use with IPv6 you want to
+  disable the use of IPv6 with the `--no-ipv6` option.
+* If you want to have the test case from which the message is printed then
+  include the `--show-testcase` option.
+* If you want to see the messages translated into another language (see
+  "[Translation]" section below) then include e.g. `--locale da` (Docker) or
+  `--locale da_DK.UTF-8` (local installation).
 
-To see all command line options, use the `--help` command.
+The same test as above with the three options included:
 
-    $ zonemaster-cli --help
+```sh
+docker run -t --rm zonemaster/cli zonemaster.net --no-ipv6 --show-testcase --locale=da
+```
+```sh
+zonemaster-cli zonemaster.net --no-ipv6 --show-testcase --locale=da_DK.UTF-8
+```
 
-### Test reports
+The difference between running `zonemaster-cli` on Docker or local installation
+is invocation string, `docker run -t --rm zonemaster/cli` vs. `zonemaster-cli`.
+To simplify this document, from now on the short `zonemaster-cli` will be used
+and for Docker the long string will be assumed. To simplify repeated invocation
+on Docker an alias can be created for the shell.
 
-The different message levels are CRITICAL, ERROR, WARNING, NOTICE, INFO,
-DEBUG, DEBUG2 and DEBUG3. The default reporting level is NOTICE and higher.
-To change the level of reporting you can use the command line switch
---level=LEVEL. The DEBUG levels are mainly used by developers, and are
-useful to debug the different test cases.
+To see all available command line options, use the `--help` command.
 
-The default level reporting is in plain english, but other output formats
-are also available. The `--lang=raw` option will give you the technical
-language output; instead of english the messages will be displayed as a
-combination of test level and test case message for easy mapping into each
-test case executed by Zonemaster. This means that the output is not
-dependent on any language changes, and better suited for automatic parsing
-of the output.
+```
+zonemaster-cli --help
+```
 
-For even better automatic parsing of the output, the option to have the
-output reported in JSON might can be used. Use `--lang=json` to have the
-output in JSON format. The JSON format is described in the
-[JSON Output](json-output.md) document.
+## Test reports
 
-More detailed documentation can by found in the [manual page](zonemaster-cli.md)
+The severity level of the different messages is CRITICAL, ERROR, WARNING, NOTICE,
+INFO, DEBUG, DEBUG2 or DEBUG3. The default reporting level is NOTICE and higher.
+To change the level of reporting you can use a command line option, e.g
+`--level=INFO` includes level INFO and higher in the report. See
+"[Severity Level Definitions]" for more information on the levels.
 
-### Advanced use
+The default level reporting is in plain English (or some other language), but
+other output formats are also available with options `--raw` and `json`
+respectively.
+
+
+## Translation
+
+### In Docker
+
+By default all messages are in English. By using the `--locale=LANG` option
+another language can be selected. Select "LANG" from the table below to have
+Zonemaster translated into that language.
+
+LANG | Language
+-----|---------
+da   | Danish
+en   | English
+fi   | Finnish
+fr   | French
+nb   | Norwegian
+es   | Spanish
+sv   | Swedish
+
+E.g.:
+```sh
+docker run -t --rm zonemaster/cli zonemaster.net --locale=da
+```
+
+An alternative is to set the `LC_ALL` environment variable with correct language
+value when the command is invoked, which can be useful if a shell alias is
+created. E.g.
+```sh
+docker run -e LC_ALL=da -t --rm zonemaster/cli zonemaster.net
+```
+
+### In local installation
+
+By default all messages are in the language set in the local environment (if
+available in Zonemaster) or else in English. By using the `--locale=LOCALE`
+option another language can be selected. Select "LOCALE" from the table below to
+have Zonemaster translated into that language.
+
+LOCALE      | Language
+------------|---------
+da_DK.UTF-8 | Danish
+en_US.UTF-8 | English
+fi_FI.UTF-8 | Finnish
+fr_FR.UTF-8 | French
+nb_NO.UTF-8 | Norwegian
+es-CL.UTF-8 | Spanish
+sv_SE.UTF-8 | Swedish
+
+E.g.:
+```sh
+docker run -t --rm zonemaster/cli zonemaster.net --locale=da_DK.UTF-8
+```
+
+If the environment variable `LANGUAGE` is set with correct LOCALE then no option
+is needed, e.g. `LANGUAGE=da_DK.UTF-8`.
+
+## Advanced use
 
 There are some nice features available that can be of some use for advanced
 users.
 
-**Save and restore**
+### Only run specific test cases
 
-You can record all data from a test session using the `--save
-filename` option to record all DNS data. This can later be replayed for
-Zonemaster using `--restore filename`, and this will make Zonemaster to
-use the saved DNS traffic for testing rather than using the live DNS tree.
-You can use this if you change your policy (see Policy configuration below)
-and see how this change will affect any previous tests, or if you find a
-strange error in a DNS configuration that is hard to duplicate - then this
-saved file can be sent to a developer that can take a closer look into the
-issue.
+If you only want to run a specific test case rather than the whole suite of
+tests, you can do that as well. E.g. test only test case [Connectivity03]:
 
-**Only run specific test**
+[Connectivity03]:  https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Connectivity-TP/connectivity03.md
 
-If you only want to run a specific test rather than the whole suite of
-tests, you can do that as well. If you want to see if the name servers for
-a domain are in enough different ASNs, you can run this test case:
+```sh
+zonemaster-cli --test Connectivity/connectivity03 example.com
+```
 
-    $ zonemaster-cli --test Connectivity/connectivity03 example.com
+Or all test case in the Connectivity test level:
+```sh
+zonemaster-cli --test Connectivity example.com
+```
 
 For more information on the available tests, you can list them right from
 the command line tool:
+```sh
+zonemaster-cli --list_tests
+```
 
-    $ zonemaster-cli --list_tests
+## Undelegated test
 
-**Halt early**
+Before you do any delegation change at the parent, either changing the NS
+records, glue address records or DS records, you might want to perform a
+check of your new child zone configuration so that everything you plan to
+change is in order. Zonemaster can do this for your. All you have to do
+is give Zonemaster all the parent data you plan to have for your new
+configuration. Any DNS lookups going for the parent will instead be
+answered by the data you entered. E.g.
 
-If you want to check a domain for some problem, but do not wish to wait
-until all tests are finished you can have Zonemaster exit when the first
-error of a certain severity level has been reached:
-
-    $ zonemaster-cli --stop_level NOTICE example.com
-
-This will halt execution as soon as a NOTICE or higher message is received.
-
-### Pre-delegation Testing
-
-Before you do any delegation change at the level of the parent, either
-changing the NS records, glue address records or DS records, you might
-want to perform a check of your new child zone configuration so that
-everything you plan to change is in order. Zonemaster can do this for
-your, all you have to do is give Zonemaster all the parent data you
-plan to have for your new configuration. Any DNS lookups going for
-the parent will instead be answered by the data you entered.
-
-    $ zonemaster-cli --ns ns1.example.com/192.168.23.23 \
-          --ns ns2.example.com/192.168.24.24 \
-          --ds 12345,3,1,123456789abcdef67890123456789abcdef67890
+```sh
+zonemaster-cli --ns ns1.example.com/192.168.23.23 \
+  --ns ns2.example.com/192.168.24.24 \
+  --ds 12345,3,1,123456789abcdef67890123456789abcdef67890
+```
 
 Any number of NS records and DS records can be given multiple times.
 The syntax of the NS records is name/address, and the address can be
 both IPv4 and IPv6. The DS syntax is keytag,algorithm,type,digest.
 
-You can also choose to do a Pre-delegation test using only the new DS
+You can also choose to do a undelegated test using only the new DS
 record, but keep the NS records from the parent by only specifying the
 DS record and no NS records on the command line.
 
 
-
-
+[Get started]:                     https://www.docker.com/get-started
+[Installation instruction]:        docs/Installation.md
+[Severity Level Definitions]:      https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[Translation]:                     #Translation

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,5 +1,19 @@
 # Installation
 
+## Table of contents
+
+* [Overview](#Overview)
+* [Docker](#Docker)
+* [Prerequisites](#Prerequisites)
+* [Local installation](#Local-installation)
+  * [Installation on Rocky Linux](#Installation-on-Rocky-Linux)
+  * [Installation on Debian or Ubuntu](#Installation-on-Debian-or-Ubuntu)
+  * [Installation on FreeBSD](#Installation-on-FreeBSD)
+* [Post-installation sanity check](#Post-installation-sanity-check)
+* [Using zonemaster-cli](#Using-zonemaster-cli)
+* [What to do next?](#What-to-do-next)
+
+
 ## Overview
 
 This document describes prerequisites, installation and post-install sanity
@@ -7,6 +21,15 @@ checking for Zonemaster::CLI. The final section wraps up with a few pointer to
 other interfaces to Zonemaster. For an overview of the Zonemaster product,
 please see the [main Zonemaster Repository].
 
+## Docker
+
+Zonemaster-CLI is available on Docker Hub and can be run on Docker without any
+installation, besides that Docker must be installed. See the [USING]
+Zonemaster-CLI document for how to run it on Docker. Links for installation of
+Docker are found there.
+
+The rest of this document is about doing a local installation of Zonemaster-CLI,
+not relevant for running Zonemaster-CLI on Docker.
 
 ## Prerequisites
 
@@ -26,14 +49,7 @@ For details on supported versions of Perl and operating system for
 Zonemaster::CLI, see the [declaration of prerequisites].
 
 
-## Installation
-
-This instruction covers the following operating systems:
-
- * [Installation on Rocky Linux]
- * [Installation on Debian]
- * [Installation on FreeBSD]
- * [Installation on Debian and Ubuntu]
+## Local installation
 
 ### Installation on Rocky Linux
 
@@ -56,7 +72,7 @@ This instruction covers the following operating systems:
    ```
 
 
-### Installation on Debian and Ubuntu
+### Installation on Debian or Ubuntu
 
 1) Update configuration of "locale"
 
@@ -116,7 +132,14 @@ Run the zonemaster-cli command:
 zonemaster-cli --test basic zonemaster.net
 ```
 
-The command is expected to take a few seconds and print some results about the delegation of zonemaster.net.
+The command is expected to take a few seconds and print some results about the
+delegation of zonemaster.net.
+
+
+## Using zonemaster-cli
+
+See the [USING] Zonemaster-CLI document for an overview on how to use
+`zonemaster-cli` after installation.
 
 
 ## What to do next?
@@ -126,16 +149,14 @@ The command is expected to take a few seconds and print some results about the d
  * For a [JSON-RPC][JSON-RPC API] frontend, follow the [Zonemaster::Backend
    installation] instruction.
 
-[Installation on Rocky Linux]: #installation-on-rocky-linux
-[Installation on Debian and Ubuntu]: #installation-on-debian-and-ubuntu
-[Installation on FreeBSD]: #installation-on-freebsd
-[Installation on Ubuntu]: #installation-on-ubuntu
 
-[Declaration of prerequisites]: https://github.com/zonemaster/zonemaster/blob/master/README.md#prerequisites
-[JSON-RPC API]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
-[Main Zonemaster repository]: https://github.com/zonemaster/zonemaster/blob/master/README.md
-[Zonemaster::Backend installation]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md
-[Zonemaster::Engine installation]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md
-[Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
-[Zonemaster::GUI installation]: https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md
-[Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
+[Declaration of prerequisites]:                   https://github.com/zonemaster/zonemaster/blob/master/README.md#prerequisites
+[JSON-RPC API]:                                   https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
+[Main Zonemaster repository]:                     https://github.com/zonemaster/zonemaster/blob/master/README.md
+[USING]:                                          ../USING.md
+[Zonemaster::Backend installation]:               https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md
+[Zonemaster::Engine installation]:                https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md
+[Zonemaster::Engine]:                             https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
+[Zonemaster::GUI installation]:                   https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md
+[Zonemaster::LDNS]:                               https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
+


### PR DESCRIPTION
## Purpose

This PR adds information for how to run Zonemaster-CLI on Docker.

* Adds information on Docker in the USING document
* Corrects the information in the USING document
* Adds table of contents in the USING document
* Adds information of translation in the USING document.
* Removes peripheral information from the USING document
* Removes detailed Docker build documentation and refers to other document.
* Adds referral to the USING document for Docker use.
* Adds table of contents to the Installation document.
* Adds referral to USING for Docker use in the Installation document.

## Changes

The following documents are updated:

* README.md
* USING.md
* docs/Installation.md

## How to test this PR

In this PR only documentation is updated. By following the instructions it could be verified.

Note that this PR adds a link to a document in the master branch that is now only available on the develop branch, but will also be available on the master branch at release.
```
https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
```
