### PR TITLE
Update PO tools

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,11 +39,11 @@ sub MY::postamble {
         # Make FreeBSD use gmake for share
         $pure_all = "GMAKE ?= \"gmake\"\n"
             . "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(GMAKE) touch-po all\n";
+            . "\tcd share && \$(GMAKE) all\n";
     } else {
         # Here Linux and GNU Make is assumed
         $pure_all = "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(MAKE) touch-po all\n";
+            . "\tcd share && \$(MAKE) all\n";
     };
 
     my $docker = <<'END_DOCKER';

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -1,21 +1,13 @@
-# This is the main Makefile in this directory and should be kept
-# GNU Make compatible.
-
 .POSIX:
 .SUFFIXES: .po .mo
-.PHONY: all dist tidy-po touch-po update-po extract-pot
+.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po
 
-DISTNAME = Zonemaster-CLI
 POFILES := $(shell find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;)
 MOFILES := $(POFILES:%.po=%.mo)
-POTFILE = $(DISTNAME).pot
+POTFILE = Zonemaster-CLI.pot
 PMFILES := $(shell find ../lib -type f -name '*.pm' | sort)
 
 all: $(MOFILES)
-	@echo
-	@echo Remember to make sure all of the above names are in the
-	@echo MANIFEST file, or they will not be installed.
-	@echo
 
 # Tidy the formatting of all PO files
 tidy-po:
@@ -23,23 +15,21 @@ tidy-po:
 	trap 'rm -rf "$$tmpdir"' EXIT ;\
 	for f in $(POFILES) ; do msgcat $$f -o $$tmpdir/$$f && mv -f $$tmpdir/$$f $$f  ; done
 
-touch-po:
-	@touch $(POTFILE) $(POFILES)
-
-update-po: extract-pot $(POFILES)
+update-po: extract-pot
+	@for f in $(POFILES) ; do msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $$f $(POTFILE) ; done
 
 extract-pot:
 	@xgettext --output $(POTFILE) --sort-by-file --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)
 
 $(POTFILE): extract-pot
 
-%.po: $(POTFILE)
-	@msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $@ $(POTFILE)
-
 .po.mo:
 	@msgfmt -o $@ $<
 	@mkdir -p locale/`basename $@ .mo`/LC_MESSAGES
-	@ln -vf $@ locale/`basename $@ .mo`/LC_MESSAGES/$(DISTNAME).mo
+	@ln -vf $@ locale/`basename $@ .mo`/LC_MESSAGES/Zonemaster-CLI.mo
 
 show-fuzzy:
 	@for f in $(POFILES) ; do msgattrib --only-fuzzy $$f ; done
+
+check-msg-args:
+	@for f in $(POFILES) ; do ../util/check-msg-args $$f ; done

--- a/share/update-po
+++ b/share/update-po
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$1" ] ; then
+    echo "error: No PO file specified." >&2
+    exit 2
+fi
+po_file="$1" ; shift
+
+make update-po POFILES="$po_file"


### PR DESCRIPTION
## Purpose

The tools for PO file generation, incl GNUmakefile, have been updated in Zonemaster-Engine (zonemaster/zonemaster-engine#929). The same solution has also been copied to Zonemaster-Backend (zonemaster/zonemaster-backend#891). 

This PR copies the same solution to Zonemaster-CLI to make it possible to have the same instructions for all three repositories.

* Updates GNUmakefile to match those of Engine and Backend
* Adds tool for PO handling from Engine
* Updates Makefile.PL to match the update of share/GNUmakefile


## Changes

* Updates  share/GNUmakefile
* Adds share/update-po 
* Updates Makefile.PL

## How to test this PR

1. Update a PO file with this PR.
2. Update the same PO file with before this PR.
3. Compare and verify that all msgid and msgstr are identical.
4. Generat MO files from identical PO files using the two solutions.
5. Verify that they are identical.
