### PR TITLE
Update MANIFEST.SKIP with missing file

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -10,6 +10,7 @@
 # Skip MO files directly under share
 ^share/[^/]*\.mo$
 ^share/Zonemaster-CLI.pot$
+^share/update-po$         # PO files are exluded from dist, which makes this script meaningless in dist
 
 # Exclude Github control files
 ^\.github/


### PR DESCRIPTION
## Purpose

`share/update-po` was added to the repository by #222, but not specified in MANIFEST or MANIFEST.SKIP. The PR adds it to MANIFEST.SKIP since it does not makes sense in the distribution.

## Changes

MANIFEST.SKIP

## How to test this PR

Make sure that distribution packages can be correctly created.