### PR TITLE
Preparation for release v2021.2 (CLI)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,23 @@
 Release history for Zonemaster component Zonemaster-CLI 
 
+v3.1.1 2021-12-03 (public release version)
+
+ [Features]
+ - Deb packages are available for Debian (#233)
+ - Adds support for Docker (#221, #218, #216)
+ - Replaces CentOS with Rocky Linux (#220)
+
+ [Fixes]
+ - Updates Finnish translation (#230, #224)
+ - Updates Norwegian translation (#228, #226)
+ - Updates Swedish translation (#227)
+ - Updates dependencies (#217)
+ - Improves DEBUG3 output (#215, #111)
+ - Improves output when option is incorrect (#214, #160)
+ - Clean-up removing unused options (#213, #145)
+ - More user-friendly options (#212, #159)
+
+
 v3.1.0 2021-05-28 (public release version)
 
  [Features]

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ requires(
     'Locale::TextDomain' => 1.23,
     'MooseX::Getopt'     => 0,
     'Text::Reflow'       => 0,
-    'Zonemaster::Engine' => 4.002,
+    'Zonemaster::Engine' => 4.003,
     'Zonemaster::LDNS'   => 2.002,
 );
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -11,7 +11,7 @@ use 5.014002;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare( "v3.5.0" );
+use version; our $VERSION = version->declare( "v3.1.1" );
 
 use Locale::TextDomain 'Zonemaster-CLI';
 use Moose;


### PR DESCRIPTION
## Purpose

* Bumps version in perl module (compared to last release)
* Updates Changes file

At last relase VERSION was `v3.1.0`. During development this has been increased to `v3.5.0` but for this release it should really be `v3.1.1` which it has been reset to in this PR.

Set this version to require latest version of Engine, which is the version that tests have run against.

## Changes

Updated files:

* Changes
* lib/Zonemaster/CLI.pm
* Makefile.PL

