### PR TITLE
Missing Spanish locale in Installation document

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -91,7 +91,7 @@ install from CPAN instead, follow the steps for Ubuntu.
 3) Update configuration of "locale"
 
    ```sh
-   sudo perl -pi -e 's/^# (da_DK\.UTF-8.*|en_US\.UTF-8.*|fi_FI\.UTF-8.*|fr_FR\.UTF-8.*|nb_NO\.UTF-8.*|sv_SE\.UTF-8.*)/$1/' /etc/locale.gen
+   sudo perl -pi -e 's/^# (da_DK\.UTF-8.*|en_US\.UTF-8.*|es_ES\.UTF-8.*|fi_FI\.UTF-8.*|fr_FR\.UTF-8.*|nb_NO\.UTF-8.*|sv_SE\.UTF-8.*)/$1/' /etc/locale.gen
    sudo locale-gen
    ```
 
@@ -99,6 +99,7 @@ install from CPAN instead, follow the steps for Ubuntu.
    ```
    da_DK.utf8
    en_US.utf8
+   es_ES.utf8
    fi_FI.utf8
    fr_FR.utf8
    nb_NO.utf8
@@ -121,7 +122,7 @@ install from CPAN instead, follow the steps for Ubuntu.
 3) Update configuration of "locale"
 
    ```sh
-   sudo perl -pi -e 's/^# (da_DK\.UTF-8.*|en_US\.UTF-8.*|fi_FI\.UTF-8.*|fr_FR\.UTF-8.*|nb_NO\.UTF-8.*|sv_SE\.UTF-8.*)/$1/' /etc/locale.gen
+   sudo perl -pi -e 's/^# (da_DK\.UTF-8.*|en_US\.UTF-8.*|es_ES\.UTF-8.*|fi_FI\.UTF-8.*|fr_FR\.UTF-8.*|nb_NO\.UTF-8.*|sv_SE\.UTF-8.*)/$1/' /etc/locale.gen
    sudo locale-gen
    ```
 
@@ -129,6 +130,7 @@ install from CPAN instead, follow the steps for Ubuntu.
    ```
    da_DK.utf8
    en_US.utf8
+   es_ES.utf8
    fi_FI.utf8
    fr_FR.utf8
    nb_NO.utf8


### PR DESCRIPTION
## Purpose

Add Spanish locale configuration in Installation document.

## Context

n/a

## Changes

Installation document.

## How to test this PR

Follow installation instructions.
