### PR TITLE
Corrects Spanish locale setting

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -171,7 +171,7 @@ en_US.UTF-8 | English
 fi_FI.UTF-8 | Finnish
 fr_FR.UTF-8 | French
 nb_NO.UTF-8 | Norwegian
-es-CL.UTF-8 | Spanish
+es_ES.UTF-8 | Spanish
 sv_SE.UTF-8 | Swedish
 
 E.g.:


### PR DESCRIPTION
## Purpose

The locale setting for Spanish is incorrect, and is corrected with this PR.

## Changes

Document USING.md is updated.

## How to test this PR

When using the locale setting from the document, `zonemaster-cli` should translate correctly.
