### PR TITLE
remove domains final dots

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -472,6 +472,8 @@ sub run {
         die __( "Must give the name of a domain to test.\n" );
     }
 
+    $domain =~ s/\.$// unless $domain eq '.';
+
     if ( $translator ) {
         if ( $self->time ) {
             print __( 'Seconds ' );
@@ -601,6 +603,8 @@ sub add_fake_delegation {
             exit( 1 );
         }
 
+        $name =~ s/\.$//;
+
         if ($ip) {
             push @{ $data{ $self->to_idn( $name ) } }, $ip;
         }
@@ -704,7 +708,7 @@ sub print_test_list {
 
 sub do_dump_profile {
     my $json = JSON::XS->new->canonical->pretty;
-    
+
     print $json->encode( Zonemaster::Engine::Profile->effective->{ q{profile} } );
 
     exit;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -603,7 +603,7 @@ sub add_fake_delegation {
             exit( 1 );
         }
 
-        $name =~ s/\.$//;
+        $name =~ s/\.$// unless $name eq '.';;
 
         if ($ip) {
             push @{ $data{ $self->to_idn( $name ) } }, $ip;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -608,7 +608,7 @@ sub add_fake_delegation {
         }
 
         if ( $name =~ m/\.\./i ) {
-            say STDERR __x( "The name of the nameserver '{ns}' contains consecutive dots.", ns => $name );
+            say STDERR __x( "The name of the nameserver '{nsname}' contains consecutive dots.", nsname => $name );
             exit ( 1 );
         }
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -472,6 +472,10 @@ sub run {
         die __( "Must give the name of a domain to test.\n" );
     }
 
+    if ( $domain =~ m/\.\./i ) {
+        die __( "The domain name contains consecutive dots.\n" );
+    }
+
     $domain =~ s/\.$// unless $domain eq '.';
 
     if ( $translator ) {
@@ -599,11 +603,16 @@ sub add_fake_delegation {
         my ( $name, $ip ) = split( '/', $pair, 2 );
 
         if ( not $name ) {
-            say STDERR "--ns must have be a name or a name/ip pair.";
+            say STDERR __( "--ns must have be a name or a name/ip pair." );
             exit( 1 );
         }
 
-        $name =~ s/\.$// unless $name eq '.';;
+        if ( $name =~ m/\.\./i ) {
+            say STDERR __x( "The name of the nameserver '{ns}' contains consecutive dots.", ns => $name );
+            exit ( 1 );
+        }
+
+        $name =~ s/\.$// unless $name eq '.';
 
         if ($ip) {
             push @{ $data{ $self->to_idn( $name ) } }, $ip;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -603,7 +603,7 @@ sub add_fake_delegation {
         my ( $name, $ip ) = split( '/', $pair, 2 );
 
         if ( not $name ) {
-            say STDERR __( "--ns must have be a name or a name/ip pair." );
+            say STDERR __( "--ns must be a name or a name/ip pair." );
             exit( 1 );
         }
 

--- a/share/fr.po
+++ b/share/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-28 16:09+0200\n"
+"POT-Creation-Date: 2022-05-03 10:32+0200\n"
 "PO-Revision-Date: 2014-08-28\n"
 "Last-Translator: pion@afnic.fr\n"
 "Language-Team: Zonemaster Team\n"
@@ -203,6 +203,9 @@ msgstr ""
 msgid "Must give the name of a domain to test.\n"
 msgstr "Il est nécessaire d'indiquer un nom de domaine pour lancer le test.\n"
 
+msgid "The domain name contains consecutive dots.\n"
+msgstr "Le nom de domaine contient des points consécutifs.\n"
+
 msgid "Seconds "
 msgstr "Durée   "
 
@@ -248,6 +251,13 @@ msgstr ""
 #, perl-format
 msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d entrées.\n"
+
+msgid "--ns must have be a name or a name/ip pair."
+msgstr "--ns doit être un nom ou un couple nom/ip."
+
+#, perl-brace-format
+msgid "The name of the nameserver '{ns}' contains consecutive dots."
+msgstr "Le nom du serveur de noms '{ns}' contient des points consécutifs."
 
 msgid ""
 "Warning: Zonemaster::LDNS not compiled with IDN support, cannot handle non-"

--- a/share/fr.po
+++ b/share/fr.po
@@ -256,8 +256,8 @@ msgid "--ns must be a name or a name/ip pair."
 msgstr "--ns doit être un nom ou un couple nom/ip."
 
 #, perl-brace-format
-msgid "The name of the nameserver '{ns}' contains consecutive dots."
-msgstr "Le nom du serveur de noms '{ns}' contient des points consécutifs."
+msgid "The name of the nameserver '{nsname}' contains consecutive dots."
+msgstr "Le nom du serveur de noms '{nsname}' contient des points consécutifs."
 
 msgid ""
 "Warning: Zonemaster::LDNS not compiled with IDN support, cannot handle non-"

--- a/share/fr.po
+++ b/share/fr.po
@@ -252,7 +252,7 @@ msgstr ""
 msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d entrées.\n"
 
-msgid "--ns must have be a name or a name/ip pair."
+msgid "--ns must be a name or a name/ip pair."
 msgstr "--ns doit être un nom ou un couple nom/ip."
 
 #, perl-brace-format


### PR DESCRIPTION
## Purpose

Do not crash when a domain is specified with a final dot.

## Context

https://github.com/zonemaster/zonemaster-engine/issues/1055

## Changes

* Remove final dot from domain if not root
* Remove final dot from NS

## How to test this PR

* `../zonemaster-cli/script/zonemaster-cli --ns ns2.nic.fr. zonemaster.net. --show-testcase` should run the test without crashing
* `../zonemaster-cli/script/zonemaster-cli --ns ns2.nic.fr.. zonemaster.net. --show-testcase` should show an error
* `../zonemaster-cli/script/zonemaster-cli --ns ns2.nic.fr. zonemaster.net.. --show-testcase` should show an error

