### PR TITLE
Use libidn2 instead of libidn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - libdevel-checklib-perl
     - libfile-sharedir-perl
     - libfile-slurp-perl
-    - libidn11-dev
+    - libidn2-dev
     - libintl-perl
     - libjson-pp-perl
     - liblist-moreutils-perl

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -669,7 +669,7 @@ sub to_idn {
         return Zonemaster::LDNS::to_idn( decode( $self->encoding, $str ) );
     }
     else {
-        say STDERR __( "Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII names correctly." );
+        say STDERR __( "Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII names correctly." );
         return $str;
     }
 }

--- a/share/da.po
+++ b/share/da.po
@@ -221,10 +221,10 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d beskeder.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Advarser: Zonemaster::LDNS er ikke kompileret med libidn, kan derfor ikke "
+"Advarser: Zonemaster::LDNS er ikke kompileret med libidn2, kan derfor ikke "
 "benytte ikke-ASCII navne."
 
 msgid "DEBUG"

--- a/share/es.po
+++ b/share/es.po
@@ -239,10 +239,10 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d registros.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Advertencia: Zonemaster::LDNS no fue compilado con libidn, no puede manejar "
+"Advertencia: Zonemaster::LDNS no fue compilado con libidn2, no puede manejar "
 "correctamente nombres no-ASCII."
 
 msgid "DEBUG"

--- a/share/fi.po
+++ b/share/fi.po
@@ -237,10 +237,10 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d merkintää.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Varoitus: Zonemaster::LDNS:n kääntämisessä ei ole käytetty libidn:iä, ei "
+"Varoitus: Zonemaster::LDNS:n kääntämisessä ei ole käytetty libidn2:iä, ei "
 "käsittele muussa kuin ASCII-muodossa olevia nimiä oikein."
 
 msgid "DEBUG"

--- a/share/fr.po
+++ b/share/fr.po
@@ -250,10 +250,10 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d entrées.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Attention: Zonemaster::LDNS n'est pas compilé avec libidn, impossible de "
+"Attention: Zonemaster::LDNS n'est pas compilé avec libidn2, impossible de "
 "traiter correctement les noms non ASCII."
 
 msgid "DEBUG"

--- a/share/nb.po
+++ b/share/nb.po
@@ -224,10 +224,10 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d meldinger.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Advarsel: Zonemaster::LDNS er ikke kompilert med libidn som gir IDNA-støtte. "
+"Advarsel: Zonemaster::LDNS er ikke kompilert med libidn2 som gir IDNA-støtte. "
 "Kan bare håndtere ASCII-navn."
 
 msgid "DEBUG"

--- a/share/sv.po
+++ b/share/sv.po
@@ -226,7 +226,7 @@ msgid "%8s\t%5d entries.\n"
 msgstr "%8s\t%5d meddelanden.\n"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
 "Varning: Zonemaster::LDNS är inte kompilerad med IDNA-stöd, så enbart ASCII-"


### PR DESCRIPTION
## Purpose

Replace libidn with libidn2.

## Context

https://github.com/zonemaster/zonemaster-ldns/pull/133

## Changes

* Update Travis dependency
* Replace references to "libidn" with "libidn2"

## How to test this PR

Using Zonemaster::LDNS (with libidn2 support), Zonemaster should work the same as before.