### PR TITLE
Add Mail::Address to zonemaster-cli dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ tests_recursive( 't' );
 requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
+    'Mail::Address'      => 0,
     'MooseX::Getopt'     => 0,
     'Text::Reflow'       => 0,
     'Zonemaster::Engine' => 4.004,


### PR DESCRIPTION
## Purpose

This PR adds Mail::Address as a dependency to zonemaster-cli, because Docker images were failing to build if that dependency was missing from Makefile.PL.

## Context

Fixes #258.

## Changes

Add “Mail::Address” as a dependency in Makefile.PL. I did not add a minimal version.

## How to test this PR

Attempt to build the Docker image for zonemaster-cli as per the instructions, and verify that `make docker-build` finishes without error.