### PR TITLE
 Adds missing installation instructions for CentOS Linux 7 (CLI)

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,6 +9,7 @@
   * [Installation on Rocky Linux](#Installation-on-Rocky-Linux)
   * [Installation on Debian and Ubuntu](#Installation-on-Debian-and-Ubuntu)
   * [Installation on FreeBSD](#Installation-on-FreeBSD)
+  * [Installation on CentOS Linux 7](#Installation-on-CentOS-Linux-7)
 * [Post-installation sanity check](#Post-installation-sanity-check)
 * [Using zonemaster-cli](#Using-zonemaster-cli)
 * [What to do next?](#What-to-do-next)
@@ -157,6 +158,28 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
    cpanm Zonemaster::CLI
    ```
 
+### Installation on CentOS Linux 7
+
+> **Please note!** CentOS 7 will only be supported until the release of
+> v2023.1, which is expected to happen during the spring of 2023.
+
+1) Install binary dependencies:
+
+   ```sh
+   sudo yum install perl-JSON-XS perl-MooseX-Getopt
+   ```
+
+2) Install dependencies from CPAN:
+
+     ```sh
+     sudo cpanm Text::Reflow Locale::TextDomain
+     ```
+
+3) Install Zonemaster::CLI
+
+   ```sh
+   sudo cpanm Zonemaster::CLI
+   ```
 
 ## Post-installation sanity check
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -161,7 +161,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 ### Installation on CentOS Linux 7
 
 > **Please note!** CentOS 7 will only be supported until the release of
-> v2023.1, which is expected to happen during the spring of 2023.
+> v2023.1, which is planned to happen during the spring of 2023.
 
 1) Install binary dependencies:
 


### PR DESCRIPTION
## Purpose

This PR adds missing installation instructions for CentOS Linux 7 (CentOS). The support for CentOS was removed in the v2021.2 release, but was readded in v2022.1 release. The installation instructions were not added.

## How to test this PR

This is documentation only.
