### PR TITLE
Fixes error in PO file that prevents MO to be created

### DIFF
--- a/share/da.po
+++ b/share/da.po
@@ -148,6 +148,7 @@ msgid ""
 msgstr ""
 "Advarsel: Kunne ikke sætte locale kategori LC_MESSAGES til %s (er det "
 "installeret på dette system?).\n"
+"\n"
 
 #, perl-format
 msgid ""
@@ -177,7 +178,7 @@ msgid "Must give the name of a domain to test.\n"
 msgstr "Domænenavn, der skal testes, skal angives.\n"
 
 msgid "The domain name contains consecutive dots.\n"
-msgstr "Domænenavnet indeholder flere dots (.) efter hinanden."
+msgstr "Domænenavnet indeholder flere dots (.) efter hinanden.\n"
 
 msgid "Seconds "
 msgstr "Sekunder "


### PR DESCRIPTION
## Purpose

PO file cannot be compiled into MO file due to a bug.

## Context

#277 describes the error, but also the problem how to discovering it early.

## Changes

Fixes the da.po.

## How to test this PR

Run the distribution process and make sure "make all" works in the root of the respository.
