### PR TITLE
Add Mac note on USING.md when it comes to Docker

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -8,6 +8,7 @@
 * [Test reports](#Test-reports)
 * [Translation]
 * [Advanced use](#Advanced-use)
+* [Docker on Mac with M1 chip](#Docker-on-Mac-with-M1-chip)
 
 
 ## Docker or local installation
@@ -254,6 +255,27 @@ both IPv4 and IPv6. The DS syntax is keytag,algorithm,type,digest.
 You can also choose to do a undelegated test using only the new DS
 record, but keep the NS records from the parent by only specifying the
 DS record and no NS records on the command line.
+
+
+## Docker on Mac with M1 chip
+
+If you run the Docker commands above on a Mac computer with the M1 chip, then you
+will get the following warning:
+
+> WARNING: The requested image's platform (linux/amd64) does not match the
+> detected host platform (linux/arm64/v8) and no specific platform was requested
+
+The warning says that the image is created for Intel/AMD64 architecture, and that
+is not what your computer has. To get rid of the warning, add
+`--platform linux/amd64` to `docker run`, e.g.
+
+```sh
+docker run --platform linux/amd64 -t --rm zonemaster/cli zonemaster.net --no-ipv6
+```
+
+If you search for the error messages you will get suggestions for how to
+automatically include the `--platform linux/amd64` option every time you run
+`docker run`.
 
 
 [Connectivity03]:                  https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Connectivity-TP/connectivity03.md


### PR DESCRIPTION
## Purpose

This PR adds a note to USING.md about a warning that is outputted when the Docker commands are run on a Mac computer with M1 chip.

## How to test this PR

Documentation only. Test that the documentation is correct.