### PR TITLE
Use lowercase fragments when referring to internal headings

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,17 +2,17 @@
 
 ## Table of contents
 
-* [Overview](#Overview)
-* [Docker](#Docker)
-* [Prerequisites for CPAN installation](#Prerequisites-for-CPAN-installation)
-* [Local installation](#Local-installation)
-  * [Installation on Rocky Linux](#Installation-on-Rocky-Linux)
-  * [Installation on Debian and Ubuntu](#Installation-on-Debian-and-Ubuntu)
-  * [Installation on FreeBSD](#Installation-on-FreeBSD)
-  * [Installation on CentOS Linux 7](#Installation-on-CentOS-Linux-7)
-* [Post-installation sanity check](#Post-installation-sanity-check)
-* [Using zonemaster-cli](#Using-zonemaster-cli)
-* [What to do next?](#What-to-do-next)
+* [Overview](#overview)
+* [Docker](#docker)
+* [Prerequisites for CPAN installation](#prerequisites-for-cpan-installation)
+* [Local installation](#local-installation)
+  * [Installation on Rocky Linux](#installation-on-rocky-linux)
+  * [Installation on Debian and Ubuntu](#installation-on-debian-and-ubuntu)
+  * [Installation on FreeBSD](#installation-on-freebsd)
+  * [Installation on CentOS Linux 7](#installation-on-centos-linux-7)
+* [Post-installation sanity check](#post-installation-sanity-check)
+* [Using zonemaster-cli](#using-zonemaster-cli)
+* [What to do next?](#what-to-do-next)
 
 
 ## Overview


### PR DESCRIPTION
## Purpose

When it comes to referring to internal anchors, we used a mix of upper and lower cases in our Markdown documents. It appears that Github handles this well, but other Markdown to HTML engines suffer to link to the related identifier on the page since they are looking for a perfect match (case sensitively).
This PR is about downcasing all fragments in our Markdown documents.

## Context

n/a

## Changes

Downcase all fragments that refer to internal anchors in our Markdown documents.

## How to test this PR

Documentation only. Links with the updated fragments should work properly once rendered.