### PR TITLE
Clean up unused import

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -23,7 +23,6 @@ use Zonemaster::Engine::Translator;
 use Zonemaster::Engine::Util qw[pod_extract_for];
 use Zonemaster::Engine::Exception;
 use Zonemaster::Engine::Zone;
-use Zonemaster::Engine::Net::IP;
 use Scalar::Util qw[blessed];
 use Encode;
 use Zonemaster::LDNS;


### PR DESCRIPTION
## Purpose

Clean up an unused import. In particular one that is about to be deprecated and eventually removed.

## Context

The issue zonemaster/zonemaster-engine#1129 has been created to deprecate Zonemaster::Engine::Net::IP.

## Changes

An unused import is removed.

## How to test this PR

Run a test using zonemaster-cli. If it doesn't crash we should be good.