### PR TITLE
List MooseX::Getopt::GLD as prereq, not MooseX::Getopt

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ tests_recursive( 't' );
 requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
-    'MooseX::Getopt'     => 0,
+    'MooseX::Getopt::GLD' => 0,
     'Text::Reflow'       => 0,
     'Zonemaster::Engine' => 4.005001,
     'Zonemaster::LDNS'   => 2.002002,


### PR DESCRIPTION
This dist uses MooseX::Getopt::GLD, not MooseX::Getopt.

MooseX::Getopt::GLD is currently packaged with MooseX::Getopt, but should still be listed as a prereq on its own.