### PR TITLE
Fail multiple domain names in entry

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -474,6 +474,10 @@ sub run {
         print "\n" if $fh_diag eq *STDOUT;
     }
 
+    if ( scalar @{ $self->extra_argv } > 1 ) {
+        die __( "Only one domain can be given for testing. Did you forget to prepend an option with '--<OPTION>'?\n" );
+    }
+
     my ( $domain ) = @{ $self->extra_argv };
     if ( not $domain ) {
         die __( "Must give the name of a domain to test.\n" );


### PR DESCRIPTION
## Purpose

It is possible to add several domain names on the command line for `zonemaster-cli` but only the first one is used. The others are ignored. This PR changes the behavior and makes it fail if more than one domain is provided.


## Context

Fixes #286.

This change could be considered to be a bug fix or a change of the API. Maybe the behavior was on purpose.

## How to test this PR

Run `zonemaster-cli` with more than one domain name on the command line. It should fail:
```
$ zonemaster-cli iis.se telia.com
Only one domain can be given for testing. Did you forget to prepend an option with '--<OPTION>'?
```
