### PR TITLE
Corrects the license statement in CLI.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ For participation, contact and bug reporting, please see the main
 [Zonemaster README].
 
 
+## License
+
+This is free software under a 2-clause BSD license. The full text of the license can
+be found in the [LICENSE](LICENSE) file included in this respository.
+
+
 [Docker Image Creation]:                          https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
 [Docker Hub]:                                     https://hub.docker.com/u/zonemaster
 [Installation]:                                   docs/Installation.md

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -792,11 +792,7 @@ Calle Dybedahl <calle at init.se>
 
 =head1 LICENSE
 
-This is free software, licensed under:
-
-The (three-clause) BSD License
-
-The full text of the license can be found in the
-F<LICENSE> file included with this distribution.
+This is free software. The full text of the license can
+be found in the F<LICENSE> file included with this distribution.
 
 =cut

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -792,7 +792,7 @@ Calle Dybedahl <calle at init.se>
 
 =head1 LICENSE
 
-This is free software. The full text of the license can
+This is free software under a 2-clause BSD license. The full text of the license can
 be found in the F<LICENSE> file included with this distribution.
 
 =cut


### PR DESCRIPTION
## Purpose

The statement about license in CLI.pm is not correct. In https://github.com/zonemaster/zonemaster-engine/issues/1149 @emollier pointed out the same issue for Zonemaster-LDNS and Zonemaster.Engine.

This PR updates the statement. It also adds the same statement to the README file.

## How to test this PR

This is documentation change only.
