### PR TITLE
USING.md: document use of --hints, also in Docker

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -232,6 +232,26 @@ the command line tool:
 zonemaster-cli --list_tests
 ```
 
+### Use custom root hints
+
+You can override the built-in list of root servers that `zonemaster-cli` uses
+by providing a path to a custom root hints file with the `--hints HINTS-FILE`
+option. For example:
+
+```sh
+zonemaster-cli --hints /path/to/custom.hints example.com
+```
+
+If you are running `zonemaster-cli` using Docker, you must mount your custom
+root hints file inside the container using a volume so that `zonemaster-cli`
+can access it, like so:
+
+```sh
+docker run -t --rm \
+    -v /path/to/custom.hints:/hints \
+    zonemaster/cli --hints /hints example.com
+```
+
 ## Undelegated test
 
 Before you do any delegation change at the parent, either changing the NS


### PR DESCRIPTION
## Purpose

This PR adds documentation for the `--hints` command-line argument and explains how to use custom root hints with the Docker image.

## Context

Fixes #290.

## Changes

See “Purpose”.

## How to test this PR

Documentation update only.
