### PR TITLE
Handle hints files named "0"

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -490,7 +490,7 @@ sub run {
     $domain =~ s/\.$// unless $domain eq '.';
     $domain = $self->to_idn( $domain );
 
-    if ( $self->hints ) {
+    if ( defined $self->hints ) {
         my $hints_data;
         try {
             my $hints_text = read_file( $self->hints );


### PR DESCRIPTION
## Purpose

This PR fixes a programming oversight causing `zonemaster-cli` to disregard hints files named `0`.

## Context

Follow-up to #284.

## Changes

Change a test for truthiness to a test for definedness.

## How to test this PR

1. Change to a working directory not containing any file named `0`.
2. Run `zonemaster-cli --hints 0 test`.
3. Expect an error message starting with: `Error loading hints file: read_file '0' - open: No such file or directory`. (The erroneous behavior was that `zonemaster-cli` attempts to run a test, disregarding the `--hints` option.)
