### PR TITLE
Zonemaster::LDNS and libldns versions

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -673,13 +673,6 @@ sub print_versions {
     say 'Engine version: ' . $Zonemaster::Engine::VERSION;
     say 'LDNS version: ' . $Zonemaster::LDNS::VERSION;
     say 'libldns version: ' . Zonemaster::LDNS::lib_version();
-    say "\nTest module versions:";
-
-    my %methods = Zonemaster::Engine->all_methods;
-    foreach my $module ( sort keys %methods ) {
-        my $mod = "Zonemaster::Engine::Test::$module";
-        say "\t$module: " . $mod->version;
-    }
 
     return;
 }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -669,10 +669,10 @@ sub add_fake_ds {
 }
 
 sub print_versions {
-    say 'CLI version:    ' . __PACKAGE__->VERSION;
-    say 'Engine version: ' . $Zonemaster::Engine::VERSION;
-    say 'LDNS version: ' . $Zonemaster::LDNS::VERSION;
-    say 'libldns version: ' . Zonemaster::LDNS::lib_version();
+    say 'Zonemaster-CLI version ' . __PACKAGE__->VERSION;
+    say 'Zonemaster-Engine version ' . $Zonemaster::Engine::VERSION;
+    say 'Zonemaster-LDNS version ' . $Zonemaster::LDNS::VERSION;
+    say 'NL NetLabs LDNS version ' . Zonemaster::LDNS::lib_version();
 
     return;
 }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -671,6 +671,8 @@ sub add_fake_ds {
 sub print_versions {
     say 'CLI version:    ' . __PACKAGE__->VERSION;
     say 'Engine version: ' . $Zonemaster::Engine::VERSION;
+    say 'LDNS version: ' . $Zonemaster::LDNS::VERSION;
+    say 'libldns version: ' . Zonemaster::LDNS::lib_version();
     say "\nTest module versions:";
 
     my %methods = Zonemaster::Engine->all_methods;


### PR DESCRIPTION
## Purpose

Show which versions of Zonemaster-LDNS and NL NetLabs LDNS are being used.
Remove module versions.

## Context

Addresses https://github.com/zonemaster/zonemaster-cli/issues/181

## Changes

CLI.pm and version() method.

## How to test this PR

Verify that the following command returns 2 new lines `LDNS version` and `libldns version`:
```
$ zonemaster-cli --version
Zonemaster-CLI version v5.0.1                                                                                          
Zonemaster-Engine version v4.6.1     
Zonemaster-LDNS version 3.1.0                    
NL NetLabs LDNS version 1.8.3
```