### PR TITLE
Make `--[no-]show-...` options work with JSON output

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -91,7 +91,7 @@ has 'json_translate' => (
     default       => 0,
     cmd_aliases   => 'json_translate',
     cmd_flag      => 'json-translate',
-    documentation => __( 'Flag indicating if streaming JSON output should include the translated message of the tag or not.' ),
+    documentation => __( 'Flag indicating if JSON output should include the translated message of the tag or not.' ),
 );
 
 has 'raw' => (
@@ -610,6 +610,11 @@ sub run {
         my $res = Zonemaster::Engine->logger->json( $self->level );
         $res = $JSON->decode( $res );
         foreach ( @$res ) {
+            if ( $self->json_translate ) {
+                my %e = %$_;
+                my $entry = Zonemaster::Engine::Logger::Entry->new( \%e );
+                $_->{message} = $json_translator->translate_tag( $entry );
+            }
             delete $_->{timestamp} unless $self->time;
             delete $_->{level} unless $self->show_level;
             delete $_->{module} unless $self->show_module;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -430,11 +430,11 @@ sub run {
                 elsif ( $self->json_stream ) {
                     my %r;
 
-                    $r{timestamp} = $entry->timestamp;
-                    $r{module}    = $entry->module;
-                    $r{testcase}  = $entry->testcase;
+                    $r{timestamp} = $entry->timestamp if $self->time;
+                    $r{module}    = $entry->module if $self->show_module;
+                    $r{testcase}  = $entry->testcase if $self->show_testcase;
                     $r{tag}       = $entry->tag;
-                    $r{level}     = $entry->level;
+                    $r{level}     = $entry->level if $self->show_level;
                     $r{args}      = $entry->args if $entry->args;
                     $r{message}   = $json_translator->translate_tag( $entry ) if $json_translator;
 
@@ -607,7 +607,15 @@ sub run {
     }
 
     if ( $self->json ) {
-        say Zonemaster::Engine->logger->json( $self->level );
+        my $res = Zonemaster::Engine->logger->json( $self->level );
+        $res = $JSON->decode( $res );
+        foreach ( @$res ) {
+            delete $_->{timestamp} unless $self->time;
+            delete $_->{level} unless $self->show_level;
+            delete $_->{module} unless $self->show_module;
+            delete $_->{testcase} unless $self->show_testcase;
+        }
+        say $JSON->encode( $res );
     }
 
     if ( $self->save ) {


### PR DESCRIPTION
## Purpose

The CLI has several options to specify which field to display. Such options are not available when using JSON output `--json` or `--json-stream`. This PR make such options work with JSON output.

## Context

https://github.com/zonemaster/zonemaster-cli/issues/247#issuecomment-1436650786

## Changes

* Make `--[no-]show-...` options work with JSON output
* Display translated message tag when passing `--json` and `--json-translate`

## How to test this PR

Try several combinations using the `--[no-]show-...` and/or `--[no-]time` options and check that the fields are properly displayed or not. Also check that the combination `--json --json-translate` properly return the translated message.
```
$ zonemaster-cli --no-show-module --show-testcase --test connectivity --level INFO --json --json-translate afnic.fr | jq
[
  {
    "args": {
      "version": "v4.6.1"
    },
    "level": "INFO",
    "message": "Using version v4.6.1 of the Zonemaster engine.",
    "tag": "GLOBAL_VERSION"
  },
  {
    "args": {
      "asn_list": "2485,2486"
    },
    "level": "INFO",
    "message": "At least two IPv4 addresses of the authoritative nameservers are announce by different AS sets. A merged list of all AS: (2485,2486).",
    "tag": "IPV4_DIFFERENT_ASN"
  },
  {
    "args": {
      "asn_list": "2485,2486"
    },
    "level": "INFO",
    "message": "At least two IPv6 addresses of the authoritative nameservers are announce by different AS sets. A merged list of all AS: (2485,2486).",
    "tag": "IPV6_DIFFERENT_ASN"
  }
]
```