### PR TITLE
Improve implementation for JSON and raw options

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -419,7 +419,7 @@ sub run {
             if ( $numeric{ uc $entry->level } >= $numeric{ $self->level } ) {
                 $printed_something = 1;
 
-                if ( $translator ) {
+                if ( not $self->raw and not $self->json ) {
                     my $header = q{};
                     if ( $self->time ) {
                         $header .= sprintf "%*.2f ", ${field_width{seconds}}, $entry->timestamp;
@@ -487,7 +487,7 @@ sub run {
                         printf "%s%s %s\n", $prefix, '>', $line;
                     }
                 }
-            } ## end if ( $numeric{ uc $entry...})
+            }
             if ( $self->stop_level and $numeric{ uc $entry->level } >= $numeric{ $self->stop_level } ) {
                 die( Zonemaster::Engine::Exception::NormalExit->new( { message => "Saw message at level " . $entry->level } ) );
             }
@@ -536,7 +536,7 @@ sub run {
         $self->add_fake_ds( $domain );
     }
 
-    if ( $translator ) {
+    if ( not $self->raw and not $self->json ) {
         my $header = q{};
 
         if ( $self->time ) {
@@ -568,7 +568,7 @@ sub run {
         $header .= sprintf "%s\n", "=" x $field_width{message};
 
         print $header;
-    } ## end if ( $translator )
+    }
 
     # Actually run tests!
     eval {
@@ -587,7 +587,7 @@ sub run {
             Zonemaster::Engine->test_zone( $domain );
         }
     };
-    if ( $translator ) {
+    if ( not $self->raw and not $self->json ) {
         if ( not $printed_something ) {
             say __( "Looks OK." );
         }
@@ -657,7 +657,7 @@ sub run {
     }
 
     return;
-} ## end sub run
+}
 
 sub add_fake_delegation {
     my ( $self, $domain ) = @_;
@@ -773,7 +773,7 @@ sub print_test_list {
         print "\n";
     }
     exit( 0 );
-} ## end sub print_test_list
+}
 
 sub do_dump_profile {
     my $json = JSON::XS->new->canonical->pretty;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -328,8 +328,27 @@ sub run {
     }
 
     if ($self->sourceaddr) {
-
         Zonemaster::Engine::Profile->effective->set( q{resolver.source}, $self->sourceaddr );
+    }
+
+    # errors and warnings
+    if ( $self->json_stream and not $self->json and grep( /^--no-json$/, @{ $self->ARGV } ) ) {
+        die __( "Error: --json-stream and --no-json can't be used together." ) . "\n";
+    }
+
+    if ( $self->json_translate ) {
+        unless ( $self->json or $self->json_stream ) {
+            printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
+        }
+        printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
+    }
+    else {
+        if ( grep( /^--no-json-translate$/, @{ $self->ARGV } ) ) {
+            unless ( $self->json or $self->json_stream ) {
+                printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
+            }
+            printf STDERR __( "Warning: deprecated --no-json-translate, use --raw instead." ) . "\n";
+        }
     }
 
     # align values

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -91,7 +91,7 @@ has 'json_translate' => (
     default       => 0,
     cmd_aliases   => 'json_translate',
     cmd_flag      => 'json-translate',
-    documentation => __( 'Flag indicating if JSON output should include the translated message of the tag or not.' ),
+    documentation => __( 'Deprecated. Flag indicating if JSON output should include the translated message of the tag or not.' ),
 );
 
 has 'raw' => (
@@ -334,7 +334,7 @@ sub run {
 
     # align values
     $self->json( 1 ) if $self->json_stream;
-    $self->raw( 0 ) if $self->json_translate;
+    $self->raw( 0 ) if $self->json_translate; # deprecated
 
     # Filehandle for diagnostics output
     my $fh_diag = ( $self->json or $self->raw )


### PR DESCRIPTION
## Purpose

Continue the work to align the Zonemaster-CLI implementation with its own documentation.

## Context

Follow-up on #308 
https://github.com/zonemaster/zonemaster-cli/issues/247#issuecomment-1436650786

## Changes

* Make `--json-stream` entail `--json`
* Deprecate `--[no-]json-translate`, use `--[no-]raw` instead
* Refactor CLI.pm

## How to test this PR

Test several configurations mixing `--json`, `--raw`, `--json-stream`.
```
zonemaster-cli --json-stream --raw zonemaster.net
zonemaster-cli --json-stream zonemaster.net
zonemaster-cli --json zonemaster.net
zonemaster-cli --json --raw zonemaster.net
zonemaster-cli --json --json-stream --raw zonemaster.net
```