### PR TITLE
New options "--sourceaddr4" and "--sourceaddr6"

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -278,8 +278,32 @@ has 'sourceaddr' => (
     isa           => 'Str',
     required      => 0,
     documentation => __(
-            'Source IP address used to send queries. '
+            'Deprecated (planned removal: v2024.1). '
+          . 'Use --sourceaddr4 and/or --sourceaddr6. '
+          . 'Source IP address used to send queries. '
           . 'Setting an IP address not correctly configured on a local network interface causes cryptic error messages.'
+    ),
+);
+
+has 'sourceaddr4' => (
+    is            => 'ro',
+    isa           => 'Str',
+    required      => 0,
+    documentation => __(
+            'Source IPv4 address used to send queries. '
+          . 'Setting an IPv4 address not correctly configured on a local network interface fails silently. '
+          . 'Can not be combined with --sourceaddr.'
+    ),
+);
+
+has 'sourceaddr6' => (
+    is            => 'ro',
+    isa           => 'Str',
+    required      => 0,
+    documentation => __(
+            'Source IPv6 address used to send queries. '
+          . 'Setting an IPv6 address not correctly configured on a local network interface fails silently. '
+          . 'Can not be combined with --sourceaddr.'
     ),
 );
 
@@ -327,8 +351,20 @@ sub run {
         print_test_list();
     }
 
-    if ($self->sourceaddr) {
+    if ( $self->sourceaddr ) {
+        if ( $self->sourceaddr4 or $self->sourceaddr6 ) {
+            die __( "Error: --sourceaddr can't be combined with --sourceaddr4 or --sourceaddr6." ) . "\n";
+        }
+        printf STDERR "%s\n\n", __( "Warning: --sourceaddr is deprecated (planned removal: v2024.1). Use --sourceaddr4 and/or --sourceaddr6 instead." );
         Zonemaster::Engine::Profile->effective->set( q{resolver.source}, $self->sourceaddr );
+    }
+
+    if ( $self->sourceaddr4 ) {
+        Zonemaster::Engine::Profile->effective->set( q{resolver.source4}, $self->sourceaddr4 );
+    }
+
+    if ( $self->sourceaddr6 ) {
+        Zonemaster::Engine::Profile->effective->set( q{resolver.source6}, $self->sourceaddr6 );
     }
 
     # errors and warnings


### PR DESCRIPTION
## Purpose

Provide options to define both source IPv4 and source IPv6. This would replace the `--sourceaddr` option.

## Context

#315 
Follow-up on https://github.com/zonemaster/zonemaster-engine/pull/1203

## Changes

* New options "--sourceaddr4" and "--sourceaddr6"
* Deprecate "--sourceaddr".

## How to test this PR

```
zonemaster-cli --sourceaddr <IP address> bzh # should emit a deprecation message
zonemaster-cli --sourceaddr4 <IPv4 address> berlin
zonemaster-cli --sourceaddr6 <IPv6 address> tokyo
```