### PR TITLE
Remove PO tests from distribution package

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -29,5 +29,4 @@ share/locale/fr/LC_MESSAGES/Zonemaster-CLI.mo
 share/locale/nb/LC_MESSAGES/Zonemaster-CLI.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-CLI.mo
 t/00-load.t
-t/po-files.t
 USING.md

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -4,6 +4,9 @@
 ^MANIFEST\.SKIP$
 ^Dockerfile$
 
+# PO files are not present in the distribution package, tests of those are irrelevant there.
+t/po-files.t
+
 \.tar\.gz$
 \.bak$
 \.po$


### PR DESCRIPTION
## Purpose

Unit tests for PO files are only relevant for CI tests, not for tests at installation. This PR removes the PO file tests from the distribution package.

## Context

Fixes #319

## Changes

Makes t/po-files.t not being included in the distribution package.

## How to test this PR

Make sure that Travis passes and installation works.
