### PR TITLE
Extend --test option to allow passing only a testcase

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -192,7 +192,7 @@ has 'test' => (
     isa           => 'ArrayRef',
     required      => 0,
     documentation => __(
-'Specify test to run case-insensitively. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a "/" character (Example: "Basic/basic01"). This switch can be repeated.'
+'Specify one or several test cases to be run. Should be the case-insensitive name of a test module and/or a test case (examples: "Delegation", "delegation01", "Delegation/delegation01"). This switch can be repeated.'
     )
 );
 
@@ -621,13 +621,24 @@ sub run {
     # Actually run tests!
     eval {
         if ( $self->test and @{ $self->test } > 0 ) {
+            my $zone = Zonemaster::Engine->zone( $domain );
             foreach my $t ( @{ $self->test } ) {
-                my ( $module, $method ) = split( '/', lc($t), 2 );
-                if ( $method ) {
-                    Zonemaster::Engine->test_method( $module, $method, Zonemaster::Engine->zone( $domain ) );
+                # The case does not matter
+                $t = lc( $t );
+                # Fully qualified module and test case (e.g. Example/example12)
+                if (my ($module, $method) = $t =~ m#^ ( [a-z]+ ) / ( [a-z]+[0-9]{2} ) $#ix) {
+                    Zonemaster::Engine->test_method( $module, $method, $zone );
                 }
+                # Just a test case (e.g. example12). Note the different capturing order.
+                elsif (($method, $module) = $t =~ m#^ ( ( [a-z]+ ) [0-9]{2} ) $#ix) {
+                    Zonemaster::Engine->test_method( $module, $method, $zone );
+                }
+                # Just a module name (e.g. Example) or something invalid.
+                # TODO: in case of invalid input, print a proper error message
+                # suggesting to use --list-tests for valid choices.
                 else {
-                    Zonemaster::Engine->test_module( $module, $domain );
+                    $t =~ s/\/$//;
+                    Zonemaster::Engine->test_module( $t, $zone );
                 }
             }
         }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -192,7 +192,7 @@ has 'test' => (
     isa           => 'ArrayRef',
     required      => 0,
     documentation => __(
-'Specify one or several test cases to be run. Should be the case-insensitive name of a test module and/or a test case (examples: "Delegation", "delegation01", "Delegation/delegation01"). This switch can be repeated.'
+'Specify test case to be run. Should be the case-insensitive name of a test module (e.g. "Delegation") and/or a test case (e.g. "Delegation/delegation01" or "delegation01"). This switch can be repeated.'
     )
 );
 
@@ -637,8 +637,8 @@ sub run {
                 # TODO: in case of invalid input, print a proper error message
                 # suggesting to use --list-tests for valid choices.
                 else {
-                    $t =~ s/\/$//;
-                    Zonemaster::Engine->test_module( $t, $zone );
+                    $t =~ s{/$}{};
+                    Zonemaster::Engine->test_module( $t, $domain );
                 }
             }
         }

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -196,12 +196,14 @@ Default: on
 
 Print all test cases listed in the test modules, then exit.
 
-=item --test=MODULE, --test=MODULE/TESTCASE
+=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
 
 Limit the testing suite to run only the specified tests.
 This can be the name of a testing module, in which case all test cases from
 that module will be run, or the name of a module followed by a slash and the
-name of a test case (test case identifier) in that module.
+name of a test case (test case identifier) in that module, or the name of the
+test case.
+Can be specified multiple times.
 This option is case-insensitive.
 
 =item --stop_level=LEVEL, --stop-level=LEVEL


### PR DESCRIPTION
## Purpose

Make it possible to only pass the name of a testcase to the `--test` option.

The following commands are now both ok and identical:
```
zonemaster-cli --test basic/basic01
zonemaster-cli --test basic01
```

## Context

Fixes #232

## Changes

* allow passing only a testcase name to the `--test` option

## How to test this PR

* run all testcases from the Basic module:
   ```
   zonemaster-cli --test basic
   ```
* run only one testcase
   ```
   zonemaster-cli --test basic/basic01
   zonemaster-cli --test basic01
   ```