### PR TITLE
Fix table layout

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -435,9 +435,17 @@ sub run {
         Zonemaster::Engine->preload_cache( $self->restore );
     }
 
+    my $level_width = 0;
+    foreach ( keys %numeric ) {
+        if ( $numeric{ $self->level } <= $numeric{$_} ) {
+            my $width_l10n = length( decode( 'UTF-8', __( $_ ) ) );
+            $level_width = $width_l10n if $width_l10n > $level_width;
+        }
+    }
+
     my %field_width = (
-        seconds  =>  7,
-        level    =>  9,
+        seconds  => 7,
+        level    => $level_width,
         module   => 12,
         testcase => 14
     );

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -438,7 +438,7 @@ sub run {
     my $level_width = 0;
     foreach ( keys %numeric ) {
         if ( $numeric{ $self->level } <= $numeric{$_} ) {
-            my $width_l10n = length( decode( 'UTF-8', __( $_ ) ) );
+            my $width_l10n = length( decode_utf8( translate_severity( $_ ) ) );
             $level_width = $width_l10n if $width_l10n > $level_width;
         }
     }
@@ -460,8 +460,8 @@ sub run {
             message  => __( 'Message' )
         );
         foreach ( keys %header_names ) {
-            $field_width{$_} = _max( $field_width{$_}, length( decode( 'UTF-8', $header_names{$_} ) ) );
-            $remaining_space{$_} = $field_width{$_} - length( decode( 'UTF-8', $header_names{$_} ) );
+            $field_width{$_} = _max( $field_width{$_}, length( decode_utf8( $header_names{$_} ) ) );
+            $remaining_space{$_} = $field_width{$_} - length( decode_utf8( $header_names{$_} ) );
         }
     }
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -500,7 +500,9 @@ sub run {
                     }
 
                     if ( $self->show_level ) {
-                        $prefix .= sprintf "%-*s ", ${field_width{level}}, $self->raw ? $entry->level : translate_severity( $entry->level );
+                        $prefix .= $self->raw ? $entry->level : translate_severity( $entry->level );
+                        my $space_l10n = ${field_width{level}} - length( decode_utf8( translate_severity($entry->level) ) ) + 1;
+                        $prefix .= ' ' x $space_l10n;
                     }
 
                     if ( $self->show_module ) {


### PR DESCRIPTION
## Purpose

PR #307 updates how the table layout is computed. It appears that the severity strings are translated and this can break the layout. This PR fixes that by computing the width taking into account the length of the translated severity strings.

## Context

Follow-up #307.
Fixes #334

## Changes

* update severity column width computation

## How to test this PR

Check that when changing the level and the locale, the table layout does not break.
```
zonemaster-cli --locale es_ES.utf8 --level CRITICAL zonemaster.net
zonemaster-cli --locale es_ES.utf8 --level DEBUG zonemaster.net
zonemaster-cli --locale sv_SE.utf8 --level CRITICAL zonemaster.net
```