### PR TITLE
Fix option --[no-]json-translate

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -88,7 +88,6 @@ has 'json_translate' => (
     traits        => [ 'Getopt' ],
     is            => 'ro',
     isa           => 'Bool',
-    default       => 0,
     cmd_aliases   => 'json_translate',
     cmd_flag      => 'json-translate',
     documentation => __( 'Deprecated. Flag indicating if JSON output should include the translated message of the tag or not.' ),
@@ -371,24 +370,21 @@ sub run {
         die __( "Error: --json-stream and --no-json can't be used together." ) . "\n";
     }
 
-    if ( $self->json_translate ) {
+    if ( defined $self->json_translate ) {
         unless ( $self->json or $self->json_stream ) {
             printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
         }
-        printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
-    }
-    else {
-        if ( grep( /^--no-?json[_-]translate$/, @{ $self->ARGV } ) ) {
-            unless ( $self->json or $self->json_stream ) {
-                printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
-            }
+        if ( $self->json_translate ) {
+            printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
+        }
+        else {
             printf STDERR __( "Warning: deprecated --no-json-translate, use --raw instead." ) . "\n";
         }
     }
 
     # align values
     $self->json( 1 ) if $self->json_stream;
-    $self->raw( $self->raw // !$self->json_translate );
+    $self->raw( $self->raw // ( defined $self->json_translate ? !$self->json_translate : 0 ) );
 
     # Filehandle for diagnostics output
     my $fh_diag = ( $self->json or $self->raw )

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -97,7 +97,6 @@ has 'json_translate' => (
 has 'raw' => (
     is            => 'rw',
     isa           => 'Bool',
-    default       => 0,
     documentation => __( 'Flag indicating if output should be translated to human language or dumped raw.' ),
 );
 
@@ -389,7 +388,7 @@ sub run {
 
     # align values
     $self->json( 1 ) if $self->json_stream;
-    $self->raw( 0 ) if $self->json_translate; # deprecated
+    $self->raw( $self->raw // !$self->json_translate );
 
     # Filehandle for diagnostics output
     my $fh_diag = ( $self->json or $self->raw )

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -379,7 +379,7 @@ sub run {
         printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
     }
     else {
-        if ( grep( /^--no-json-translate$/, @{ $self->ARGV } ) ) {
+        if ( grep( /^--no-json[_-]translate$/, @{ $self->ARGV } ) ) {
             unless ( $self->json or $self->json_stream ) {
                 printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
             }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -368,7 +368,7 @@ sub run {
     }
 
     # errors and warnings
-    if ( $self->json_stream and not $self->json and grep( /^--no-json$/, @{ $self->ARGV } ) ) {
+    if ( $self->json_stream and not $self->json and grep( /^--no-?json$/, @{ $self->ARGV } ) ) {
         die __( "Error: --json-stream and --no-json can't be used together." ) . "\n";
     }
 
@@ -379,7 +379,7 @@ sub run {
         printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
     }
     else {
-        if ( grep( /^--no-json[_-]translate$/, @{ $self->ARGV } ) ) {
+        if ( grep( /^--no-?json[_-]translate$/, @{ $self->ARGV } ) ) {
             unless ( $self->json or $self->json_stream ) {
                 printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
             }

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -129,8 +129,6 @@ For streaming JSON output, include the translated message of the tag.
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
 
-Default: off
-
 =item --[no-]time
 
 Print the timestamp for each message.


### PR DESCRIPTION
## Purpose

This PR fixes 2 small error/bugs discovered during v2023.1 release testing.

## Context

#308 https://github.com/zonemaster/zonemaster-cli/pull/309
v2023.1 release testing comment https://github.com/zonemaster/zonemaster-cli/pull/308#issuecomment-1570279972
v2023.1 release testing comment https://github.com/zonemaster/zonemaster-cli/pull/309#issuecomment-1570297400

## Changes

* fix ineffective `--no-json-translate` option
* show deprectation warning with option alias `--[no-]json_translate`

## How to test this PR

* Check that `--[no-]json_translate` option gives a deprecation warning. 
* Check that `--no-json-translate` does not output the `message` key.
