### PR TITLE
Make --test case-insensitive

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -192,7 +192,7 @@ has 'test' => (
     isa           => 'ArrayRef',
     required      => 0,
     documentation => __(
-'Specify test to run. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a "/" character (Example: "Basic/basic01"). This switch can be repeated.'
+'Specify test to run case-insensitively. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a "/" character (Example: "Basic/basic01"). This switch can be repeated.'
     )
 );
 
@@ -622,7 +622,7 @@ sub run {
     eval {
         if ( $self->test and @{ $self->test } > 0 ) {
             foreach my $t ( @{ $self->test } ) {
-                my ( $module, $method ) = split( '/', $t, 2 );
+                my ( $module, $method ) = split( '/', lc($t), 2 );
                 if ( $method ) {
                     Zonemaster::Engine->test_method( $module, $method, Zonemaster::Engine->zone( $domain ) );
                 }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -192,7 +192,7 @@ has 'test' => (
     isa           => 'ArrayRef',
     required      => 0,
     documentation => __(
-'Specify test to run. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a "/" character (Example: "Basic/basic1"). The method specified must be one that takes a zone object as its single argument. This switch can be repeated.'
+'Specify test to run. Should be either the name of a module, or the name of a module and the name of a method in that module separated by a "/" character (Example: "Basic/basic01"). This switch can be repeated.'
     )
 );
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -202,6 +202,7 @@ Limit the testing suite to run only the specified tests.
 This can be the name of a testing module, in which case all test cases from
 that module will be run, or the name of a module followed by a slash and the
 name of a test case (test case identifier) in that module.
+This option is case-insensitive.
 
 =item --stop_level=LEVEL, --stop-level=LEVEL
 


### PR DESCRIPTION
## Context

Seen as a bug, see comment https://github.com/zonemaster/zonemaster-cli/pull/333#discussion_r1247918347

## How to test this PR

All should work:
```
zonemaster-cli --show-testcase --test basic/basic01 kyoto
zonemaster-cli --show-testcase --test BASIC/BASIC01 melbourne
zonemaster-cli --show-testcase --test BAsiC rio
zonemaster-cli --show-testcase --test bAsIc/BaSiC01 quebec
```