### PR TITLE
fix typo

### DIFF
--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -159,7 +159,7 @@ Provide information about a nameserver, for undelegated tests. The argument
 must be either: (i) a domain name and an IP address, separated by a single
 slash character (/), or (ii) only a domain name, in which case a A and AAAA
 records lookup for that name is done in the live global DNS tree (unless 
-overriden by --hints) and from which the results of that lookup will be used.
+overridden by --hints) and from which the results of that lookup will be used.
 
 This switch can be given multiple times. As long as any of these switches
 are present, their aggregated content will be used as the


### PR DESCRIPTION
## Purpose

This is a fix for a typo.

## Context

The typo leaked to the manual page, which in turn was caught by our linter.

## Changes

The change affects script/zonemaster-cli pod.

## How to test this PR

The PR can be tested using a spell checker?  :)

I'm not a native English speaker, so there is always the risk that dialect specific checkers (e.g. American versus British) may raise different orthographs.