### PR TITLE
Fix raw ouput

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -511,11 +511,10 @@ sub run {
                     if ( $self->raw ) {
                         $prefix .= $entry->tag;
 
-                        my $message = $entry->string;
-                        $message =~ s/^[A-Z0-9:_]+//;    # strip MODULE:TAG, they're coming in $prefix instead
+                        my $message = $entry->argstr;
                         my @lines = split /\n/, $message;
 
-                        printf "%s%s %s\n", $prefix, ' ', shift @lines;
+                        printf "%s%s %s\n", $prefix, ' ', @lines ? shift @lines : '';
                         for my $line ( @lines ) {
                             printf "%s%s %s\n", $prefix, '>', $line;
                         }


### PR DESCRIPTION
## Purpose

Fix raw output

## Context

When using https://github.com/zonemaster/zonemaster-engine/pull/1302 the raw ouput is broken as the CLI was relying on the fact that module / testcase / tag to strip them from the message.

Instead of changing the regex, let's use a new method that return only the message arguments, which is less error prone.

## Changes

* Use the new method `$entry->argstr` instead of removing the prefix of the output of `$entry->string`.

## How to test this PR

Check that the raw ouput working correctly, in particular check that after the message tag only the arguments are displayed and no garbage of any sort.

Before the PR
```
% zonemaster-cli --level info --show-module --show-testcase afnic.fr --test connectivity --raw
   0.00 INFO     System       Unspecified    GLOBAL_VERSION  ystem:Unspecified:GLOBAL_VERSION version=v4.7.3
   1.71 INFO     Connectivity Connectivity03 IPV4_DIFFERENT_ASN  onnectivity:Connectivity03:IPV4_DIFFERENT_ASN asn_list=42,2485,2486
   1.71 INFO     Connectivity Connectivity03 IPV6_DIFFERENT_ASN  onnectivity:Connectivity03:IPV6_DIFFERENT_ASN asn_list=42,2485,2486
   1.72 INFO     Connectivity Connectivity04 CN04_IPV4_DIFFERENT_PREFIX  onnectivity:Connectivity04:CN04_IPV4_DIFFERENT_PREFIX ns_list=g.ext.nic.fr/194.0.36.1;ns1.nic.fr/192.134.4.1;ns2.nic.fr/192.93.0.4;ns3.nic.fr/192.134.0.49
   1.72 INFO     Connectivity Connectivity04 CN04_IPV6_DIFFERENT_PREFIX  onnectivity:Connectivity04:CN04_IPV6_DIFFERENT_PREFIX ns_list=g.ext.nic.fr/2001:678:4c::1;ns1.nic.fr/2001:67c:2218:2::4:1;ns2.nic.fr/2001:660:3005:1::1:2;ns3.nic.fr/2001:660:3006:1::1:1
```

After

```
% zonemaster-cli --level info --show-module --show-testcase afnic.fr --test connectivity --raw
   0.00 INFO     System       Unspecified    GLOBAL_VERSION  version=v4.7.3
   1.75 INFO     Connectivity Connectivity03 IPV4_DIFFERENT_ASN  asn_list=42,2485,2486
   1.75 INFO     Connectivity Connectivity03 IPV6_DIFFERENT_ASN  asn_list=42,2485,2486
   1.76 INFO     Connectivity Connectivity04 CN04_IPV4_DIFFERENT_PREFIX  ns_list=g.ext.nic.fr/194.0.36.1;ns1.nic.fr/192.134.4.1;ns2.nic.fr/192.93.0.4;ns3.nic.fr/192.134.0.49
   1.76 INFO     Connectivity Connectivity04 CN04_IPV6_DIFFERENT_PREFIX  ns_list=g.ext.nic.fr/2001:678:4c::1;ns1.nic.fr/2001:67c:2218:2::4:1;ns2.nic.fr/2001:660:3005:1::1:2;ns3.nic.fr/2001:660:3006:1::1:1
```