### PR TITLE
Fix domain name command line argument handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ RUN apk add --no-cache \
     perl-app-cpanminus \
     perl-module-install \
  && cpanm --no-wget --from https://cpan.metacpan.org/ \
-    MooseX::Getopt \
-    Text::Reflow
+    MooseX::Getopt
 
 ARG version
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,6 @@ requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
     'MooseX::Getopt'     => 0,
-    'Text::Reflow'       => 0,
     'Try::Tiny'          => 0,
     'Zonemaster::LDNS'   => 3.002000,  # v3.2.0
     'Zonemaster::Engine' => 4.007003,  # v4.7.3

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -628,11 +628,6 @@ sub run {
         }
     );
 
-    if ( $self->profile or $self->test ) {
-        # Separate initialization from main output in human readable output mode
-        print "\n" if $fh_diag eq *STDOUT;
-    }
-
     if ( scalar @{ $self->extra_argv } > 1 ) {
         die __( "Only one domain can be given for testing. Did you forget to prepend an option with '--<OPTION>'?\n" );
     }
@@ -672,6 +667,11 @@ sub run {
 
     if ( $self->ds and @{ $self->ds } ) {
         $self->add_fake_ds( $domain );
+    }
+
+    if ( $self->profile or $self->test ) {
+        # Separate initialization from main output in human readable output mode
+        print "\n" if $fh_diag eq *STDOUT;
     }
 
     if ( not $self->raw and not $self->json ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -634,7 +634,7 @@ sub run {
 
     my ( $domain ) = @{ $self->extra_argv };
 
-    if ( not $domain ) {
+    if ( !defined $domain ) {
         die __( "Must give the name of a domain to test.\n" );
     }
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -24,8 +24,6 @@ use JSON::XS;
 use List::Util qw[max uniq];
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
 use Scalar::Util qw[blessed];
-use Socket qw[AF_INET AF_INET6];
-use Text::Reflow qw[reflow_string];
 use Try::Tiny;
 use Net::IP::XS;
 
@@ -36,7 +34,6 @@ use Zonemaster::Engine::Normalization qw[normalize_name];
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::Engine::Translator;
 use Zonemaster::Engine::Util qw[parse_hints];
-use Zonemaster::Engine::Zone;
 
 our %numeric = Zonemaster::Engine::Logger::Entry->levels;
 our $JSON    = JSON::XS->new->allow_blessed->convert_blessed->canonical;


### PR DESCRIPTION
## Purpose

This PR fixes a couple of issues related to command line argument handling.

## Context

This PR fixes items 1 and 2 in #364.

## Changes

* Domain names "" and "0" are not rejected as missing domain names.
* The diagnostics/results separator is printed after input validation is completed.
* As a drive-by change, the unused Test::Reflow dependency is also removed.

## How to test this PR
Zonemaster CLI should present the following behaviors:
```
$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 
Must give the name of a domain to test.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 ''
Domain name is empty


$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 0                                                                                                                                      

Seconds Level    Testcase       Message
======= ======== ============== =======
...
```