### PR TITLE
Make usage documentation consistent and also demoose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,6 @@ before_install:
   # Zonemaster LDNS needs a newer version of Module::Install
 - cpan-install Module::Install Module::Install::XSUtil
 
-  # Moose installed from OS package depends on a newer version of Devel::OverloadInfo
-- cpan-install Devel::OverloadInfo Moose MooseX::Getopt
-
   # IO::Socket::INET6 can't find Socket6 installed from OS package
 - cpan-install Socket6 IO::Socket::INET6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,29 @@
 FROM zonemaster/engine:local as build
 
 RUN apk add --no-cache \
-    build-base \
     make \
     perl-app-cpanminus \
-    perl-cpan-meta-check \
-    perl-data-dump \
-    perl-dev \
-    perl-doc \
     perl-json-xs \
     perl-lwp-protocol-https \
-    perl-module-build \
-    perl-module-build-tiny \
-    perl-module-install \
-    perl-moose \
-    perl-namespace-autoclean \
-    perl-params-validate \
-    perl-path-tiny \
+    perl-mojolicious \
     perl-test-deep \
-    perl-test-needs \
- && cpanm --no-wget --from https://cpan.metacpan.org/ \
-    MooseX::Getopt
+    perl-test-differences \
+    perl-try-tiny \
+ && cpanm --notest --no-wget --from https://cpan.metacpan.org/ \
+    JSON::Validator
 
 ARG version
 
 COPY ./Zonemaster-CLI-${version}.tar.gz ./Zonemaster-CLI-${version}.tar.gz
 
-RUN cpanm --no-wget \
+RUN cpanm --notest --no-wget \
     ./Zonemaster-CLI-${version}.tar.gz
 
 FROM zonemaster/engine:local
 
 RUN apk add --no-cache \
-    perl-namespace-autoclean \
-    perl-params-validate \
     perl-json-xs \
-    perl-moose
+    perl-try-tiny
 
 COPY --from=build /usr/local/bin/zonemaster-cli /usr/local/bin/zonemaster-cli
 # Include all the Perl modules we built

--- a/MANIFEST
+++ b/MANIFEST
@@ -27,6 +27,7 @@ share/locale/fr/LC_MESSAGES/Zonemaster-CLI.mo
 share/locale/nb/LC_MESSAGES/Zonemaster-CLI.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-CLI.mo
 t/00-load.t
+t/pod.t
 t/usage.fake-data.data
 t/usage.fake-root.data
 t/usage.hints

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,6 @@ requires(
     'Net::IP::XS'        => 0,
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
-    'MooseX::Getopt'     => 0,
     'Try::Tiny'          => 0,
     'Zonemaster::LDNS'   => 4.000002,  # v4.0.2
     'Zonemaster::Engine' => 6.000000,  # v6.0.0

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -53,7 +53,7 @@ if ( defined $global_conf_file ) {
 }
 
 eval {
-    my $exitstatus = Zonemaster::CLI->new_with_options->run;
+    my $exitstatus = Zonemaster::CLI->run( @ARGV );
     exit $exitstatus;
 };
 
@@ -90,23 +90,28 @@ Print the available command line switches, then exit.
 
 =item --version
 
-Print the versions of this program as well as the ones from the underlying 
-L<Zonemaster> test engine, then exit.
+Print version information and exit.
+
+=for :man The printed version numbers are the versions of this program as well as the ones from the underlying
+L<Zonemaster> test engine.
 
 =item --level=LEVEL
 
-Specify the minimum level of a message to be printed. Messages with this level
-(or higher) will be printed. The levels are, from highest to lowest: 
+Specify the minimum level of a message to be printed.
+Default: NOTICE
+
+=for :man Messages with this level
+(or higher) will be printed. The levels are, from highest to lowest:
 CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, DEBUG2 and DEBUG3.
 The lowest three levels (DEBUG) add a significant amount of messages to be shown.
-They reveal some of the internal workings of the test engine, and are probably 
+They reveal some of the internal workings of the test engine, and are probably
 not useful for most users.
-
-Default: NOTICE
 
 =item --locale=LOCALE
 
-Specify which locale to be used by the translation system. If not given, the
+Specify which locale to be used by the translation system.
+
+=for :man If not given, the
 translation system itself will look at environment variables to try and guess.
 If the requested translation does not exist, it will fallback to the local
 locale, and if that doesn't exist either, to English.
@@ -114,21 +119,20 @@ locale, and if that doesn't exist either, to English.
 =item --[no-]json
 
 Print results as JSON instead of human language.
-
 Default: off
 
 =item --[no-]json_stream, --[no-]json-stream
 
-Stream the results as JSON. Useful to follow the progress in a
-machine-readable way.
-
+Stream the results as JSON.
 Default: off
+
+=for :man Useful to follow the progress in a machine-readable way.
 
 =item --[no-]json_translate, --[no-]json-translate
 
 Deprecated since v2023.1, use --no-raw instead.
 
-For streaming JSON output, include the translated message of the tag.
+=for :man For streaming JSON output, include the translated message of the tag.
 
 =item --[no-]raw
 
@@ -138,36 +142,34 @@ to human language.
 =item --[no-]time
 
 Print the timestamp for each message.
-
 Default: on
 
 =item --[no-]show_level, --[no-]show-level
 
 Print the severity level for each message.
-
 Default: on
 
 =item --[no-]show_module, --[no-]show-module
 
 Print the name of the module which produced the message.
-
 Default: off
 
 =item --[no-]show_testcase, --[no-]show-testcase
 
 Print the name of the test case (test case identifier) which produced the message.
-
 Default: off
 
 =item --ns=NAME[/IP]
 
-Provide information about a nameserver, for undelegated tests. The argument
+Provide information about a nameserver, for undelegated tests.
+
+=for :man The argument
 must be either: (i) a domain name and an IP address, separated by a single
 slash character (/), or (ii) only a domain name, in which case a A and AAAA
-records lookup for that name is done in the live global DNS tree (unless 
+records lookup for that name is done in the live global DNS tree (unless
 overridden by --hints) and from which the results of that lookup will be used.
 
-This switch can be given multiple times. As long as any of these switches
+=for :man This switch can be given multiple times. As long as any of these switches
 are present, their aggregated content will be used as the
 entirety of the parent-side delegation information.
 
@@ -183,19 +185,19 @@ after the testing suite has finished running.
 =item --restore=FILENAME
 
 Prime the DNS packet cache with the contents from the file with the given name
-before starting the testing suite. The format of the file should be from one
-produced by the --save switch.
+before starting the testing suite.
+
+=for :man The format of the file should be from one produced by the --save
+switch.
 
 =item --[no-]ipv4
 
 Allow the sending of IPv4 packets.
-
 Default: on
 
 =item --[no-]ipv6
 
 Allow the sending of IPv6 packets.
-
 Default: on
 
 =item --list_tests, --list-tests
@@ -205,17 +207,19 @@ Print all test cases listed in the test modules, then exit.
 =item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
 
 Limit the testing suite to run only the specified tests.
-This can be the name of a testing module, in which case all test cases from
+Can be specified multiple times.
+
+=for :man This can be the name of a testing module, in which case all test cases from
 that module will be run, or the name of a module followed by a slash and the
 name of a test case (test case identifier) in that module, or the name of the
 test case.
-Can be specified multiple times.
 This option is case-insensitive.
 
 =item --stop_level=LEVEL, --stop-level=LEVEL
 
 Specify the minimum severity level after which the testing suite is terminated.
-The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
+
+=for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
 INFO, DEBUG, DEBUG2 and DEBUG3.
 
 =item --profile=FILE
@@ -226,7 +230,9 @@ the given profile JSON file.
 =item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
 
 Provide a DS record for undelegated testing (that is, a test where the
-delegating nameserver information is given via --ns switches). The four pieces
+delegating nameserver information is given via --ns switches).
+
+=for :man The four pieces
 of data (keytag, algorithm, type, digest) should be in the same format they would
 have in a zone file.
 
@@ -234,15 +240,14 @@ have in a zone file.
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
 level that were logged during the run.
-
 Default: off
 
 =item --[no-]progress
 
-Print an activity indicator ("spinner"). Useful to know that something is
-happening during a run.
-
+Print an activity indicator ("spinner").
 Default: on (if the process' standard output is a TTY)
+
+=for :man Useful to know that something is happening during a run.
 
 =item --encoding=ENCODING
 
@@ -260,19 +265,20 @@ Print the effective profile used in JSON format, then exit.
 =item --sourceaddr4=IPADDR
 
 Specify the source IPv4 address used to send queries.
-Setting an IPv4 address not correctly configured on a local network interface
+
+=for :man Setting an IPv4 address not correctly configured on a local network interface
 fails silently.
 
 =item --sourceaddr6=IPADDR
 
 Specify the source IPv6 address used to send queries.
-Setting an IPv6 address not correctly configured on a local network interface
+
+=for :man Setting an IPv6 address not correctly configured on a local network interface
 fails silently.
 
 =item --[no-]elapsed
 
 Print elapsed time (in seconds) at end of a run.
-
 Default: off
 
 =back

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,18 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+# Ensure a recent version of Test::Pod
+my $min_tp = 1.22;
+eval "use Test::Pod $min_tp";
+plan skip_all => "Test::Pod $min_tp required for testing POD" if $@;
+
+my @poddirs;
+push @poddirs, ( -e 'lib' ? 'lib' : 'blib' );
+push @poddirs, 'script';
+
+all_pod_files_ok( all_pod_files( @poddirs ) );
+
+done_testing;

--- a/t/usage.t
+++ b/t/usage.t
@@ -537,6 +537,18 @@ do {
     check_usage_error 'Bad --hints (syntax)', [ '--hints', 't/usage.t', 'example.' ],
       qr{error loading hints file}i;
 
+    check_success '--help', ['--help'], qr{
+        --test
+    }msx;
+
+    check_success '-h', ['-h'], qr{
+        --test
+    }msx;
+
+    check_success 'Single-character option bundling', ['-h?'], qr{
+        --test
+    }msx;
+
     check_success '--version', ['--version'], qr{
         ^\QZonemaster-CLI version\E .*
         ^\QZonemaster-Engine version\E .*

--- a/t/usage.t
+++ b/t/usage.t
@@ -538,10 +538,22 @@ do {
       qr{error loading hints file}i;
 
     check_success '--help', ['--help'], qr{
+        ^Usage:$
+        .*
+        zonemaster-cli
+        .*
+        ^Options:$
+        .*
         --test
     }msx;
 
     check_success '-h', ['-h'], qr{
+        ^Usage:$
+        .*
+        zonemaster-cli
+        .*
+        ^Options:$
+        .*
         --test
     }msx;
 

--- a/t/usage.wrapper.pl
+++ b/t/usage.wrapper.pl
@@ -10,6 +10,9 @@ use Zonemaster::Engine::Profile;
 
 use lib catfile( dirname( dirname( __FILE__ ) ), 'script' );
 
+# Help Zonemaster::CLI find zonemaster-cli in test context
+$Zonemaster::CLI::SCRIPT = catfile( dirname( dirname( __FILE__ ) ), 'script', 'zonemaster-cli' );
+
 # Parse command line options upto and including '--'.
 
 my $opt_record = 0;
@@ -60,7 +63,7 @@ do {
 
     # Run Zonemaster::CLI
     eval {
-        $EXIT_STATUS = Zonemaster::CLI->new_with_options->run;
+        $EXIT_STATUS = Zonemaster::CLI->run( @ARGV );
         1;
     } or do {
         print STDERR $@;


### PR DESCRIPTION
## Purpose

This PR kills two birds with one stone:
 * It fixes the discrepancy between perldoc zonemaster-cli and zonemaster-cli --help, and
 * it migrates away from Moose and Moosex::Getopt::GLD.

## Context

* Fixes #68.
* I've tried to keep this PR conservative with regards to improving the actual help text. I have a lot of improvements in mind but I'm deferring them to one or more followup PRs. See #389.

## Changes

Application:
 * Instead of using Moose and Moosex::Getopt::GLD we now Getopt::Long and Pod::Usage which are both Perl core modules.
 * I merged the best parts of the --help and perldoc usage texts. As I worked through them I realized there was a lot of room for further improvement. I tried to be conservative making improvements but in some cases I couldn't help myself.

Tests:
 * A unit test is added to make sure --help work.
 * A unit test is added to make sure all POD is syntactically correct.

Documentation:
 * The --help text is longer now and formatted differently. This because we're using a different method of generating it and the details are taken from POD instead of Moose attributes.

## Reviewing this PR

* Inspect the help text and man page of both this branch and the develop branch looking details that have gone missing.

## Testing this PR

* Unit tests should pass.
* Perform a limited amount of exploratory testing for edge cases like missing required arguments, unknown options, invalid arguments, or conflicting flags.