### PR TITLE
Speed up Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
 FROM zonemaster/engine:local as build
 
 RUN apk add --no-cache \
-    # Only needed for Net::Interface
     build-base \
+    make \
+    perl-app-cpanminus \
+    perl-cpan-meta-check \
+    perl-data-dump \
     perl-dev \
     perl-doc \
+    perl-json-xs \
     perl-lwp-protocol-https \
-    make \
-    # Compile-time dependencies
-    perl-app-cpanminus \
+    perl-module-build \
+    perl-module-build-tiny \
     perl-module-install \
+    perl-moose \
+    perl-namespace-autoclean \
+    perl-params-validate \
+    perl-path-tiny \
+    perl-test-deep \
+    perl-test-needs \
  && cpanm --no-wget --from https://cpan.metacpan.org/ \
     MooseX::Getopt
 
@@ -21,6 +30,12 @@ RUN cpanm --no-wget \
     ./Zonemaster-CLI-${version}.tar.gz
 
 FROM zonemaster/engine:local
+
+RUN apk add --no-cache \
+    perl-namespace-autoclean \
+    perl-params-validate \
+    perl-json-xs \
+    perl-moose
 
 COPY --from=build /usr/local/bin/zonemaster-cli /usr/local/bin/zonemaster-cli
 # Include all the Perl modules we built


### PR DESCRIPTION
## Purpose

This PR amends the Dockerfile for zonemaster-cli so as to install as many prerequisite packages from binary packages as possible, thereby speeding up the build.

## Context

Release testing for v2024.1.

## Changes

 * Install most transitive dependencies for Zonemaster-CLI by means of binary packages.

## How to test this PR

Try to build the Docker image. The build process should only pick up six small packages from CPAN. Notably, Moose shouldn’t be picked up from CPAN.
