### PR TITLE
Fixing errors display when using options '--ns' or '--ds'

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -882,11 +882,10 @@ sub check_fake_delegation {
 
         if ( $ip ) {
             my $net_ip = Net::IP::XS->new( $ip );
-            if ( not(
-                     ( $ip =~ /($IPV4_RE)/ && Net::IP::XS::ip_is_ipv4( $ip ) )
-                      or
-                     ( $ip =~ /($IPV6_RE)/ && Net::IP::XS::ip_is_ipv6( $ip ) )
-                    )
+            unless (
+                ( $ip =~ /($IPV4_RE)/ && Net::IP::XS::ip_is_ipv4( $ip ) )
+                or
+                ( $ip =~ /($IPV6_RE)/ && Net::IP::XS::ip_is_ipv6( $ip ) )
             )
 	    {
                 die Net::IP::XS::Error() ? "Invalid IP address in --ns argument:\n\t". Net::IP::XS::Error() ."\n" : "Invalid IP address in --ns argument.\n";

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -647,7 +647,14 @@ sub run {
     ( my $errors, $domain ) = normalize_name( decode( 'utf8', $domain ) );
 
     if ( $self->ns and @{ $self->ns } > 0 ) {
-        $self->check_fake_delegation( $domain );
+        local $@;
+        eval {
+            $self->check_fake_delegation( $domain );
+            1;
+        } or do {
+            print STDERR $@;
+            return $EXIT_USAGE_ERROR;
+        };
     }
 
     if ( $self->ds and @{ $self->ds } ) {
@@ -685,14 +692,7 @@ sub run {
     }
 
     if ( $self->ns and @{ $self->ns } > 0 ) {
-        local $@;
-        eval {
-            $self->add_fake_delegation( $domain );
-            1;
-        } or do {
-            print STDERR $@;
-            return $EXIT_USAGE_ERROR;
-        };
+        $self->add_fake_delegation( $domain );
     }
 
     if ( $self->ds and @{ $self->ds } ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -647,6 +647,14 @@ sub run {
 
     ( my $errors, $domain ) = normalize_name( decode( 'utf8', $domain ) );
 
+    if ( $self->ns and @{ $self->ns } > 0 ) {
+        $self->check_fake_delegation( $domain );
+    }
+
+    if ( $self->ds and @{ $self->ds } ) {
+        $self->check_fake_ds( $domain );
+    }
+
     if ( scalar @$errors > 0 ) {
         my $error_message;
         foreach my $err ( @$errors ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -33,6 +33,7 @@ use Zonemaster::Engine::Normalization qw[normalize_name];
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::Engine::Translator;
 use Zonemaster::Engine::Util qw[parse_hints];
+use Zonemaster::Engine::Validation qw[validate_ipv4 validate_ipv6];
 
 our %numeric = Zonemaster::Engine::Logger::Entry->levels;
 our $JSON    = JSON::XS->new->allow_blessed->convert_blessed->canonical;
@@ -41,8 +42,6 @@ Readonly our $EXIT_SUCCESS       => 0;
 Readonly our $EXIT_GENERIC_ERROR => 1;
 Readonly our $EXIT_USAGE_ERROR   => 2;
 
-Readonly our $IPV4_RE => qr/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
-Readonly our $IPV6_RE => qr/^[0-9a-f:]*:[0-9a-f:]+(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?$/i;
 Readonly our $DS_RE => qr/^(?:[[:digit:]]+,){3}[[:xdigit:]]+$/;
 
 STDOUT->autoflush( 1 );
@@ -890,11 +889,7 @@ sub check_fake_delegation {
 
         if ( $ip ) {
             my $net_ip = Net::IP::XS->new( $ip );
-            unless (
-                ( $ip =~ /($IPV4_RE)/ && Net::IP::XS::ip_is_ipv4( $ip ) )
-                or
-                ( $ip =~ /($IPV6_RE)/ && Net::IP::XS::ip_is_ipv6( $ip ) )
-            )
+	    unless( validate_ipv4( $ip ) or validate_ipv6( $ip ) )
 	    {
                 die Net::IP::XS::Error() ? "Invalid IP address in --ns argument:\n\t". Net::IP::XS::Error() ."\n" : "Invalid IP address in --ns argument.\n";
             }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -691,14 +691,6 @@ sub run {
         Zonemaster::Engine::Recursor->add_fake_addresses( '.', $hints_data );
     }
 
-    if ( $self->ns and @{ $self->ns } > 0 ) {
-        $self->add_fake_delegation( $domain );
-    }
-
-    if ( $self->ds and @{ $self->ds } ) {
-        $self->add_fake_ds( $domain );
-    }
-
     if ( $self->profile or $self->test ) {
         # Separate initialization from main output in human readable output mode
         print "\n" if $fh_diag eq *STDOUT;
@@ -736,6 +728,14 @@ sub run {
         $header .= sprintf "%s\n", "=" x $field_width{message};
 
         print $header;
+    }
+
+    if ( $self->ns and @{ $self->ns } > 0 ) {
+        $self->add_fake_delegation( $domain );
+    }
+
+    if ( $self->ds and @{ $self->ds } ) {
+        $self->add_fake_ds( $domain );
     }
 
     # Actually run tests!

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -861,9 +861,7 @@ sub run {
 
 
 sub check_fake_delegation {
-    my ( $self, $domain ) = @_;
-    my @ns_with_no_ip;
-    my %data;
+    my ( $self ) = @_;
 
     foreach my $pair ( @{ $self->ns } ) {
         my ( $name, $ip ) = split( '/', $pair, 2 );
@@ -900,8 +898,7 @@ sub check_fake_delegation {
 }
 
 sub check_fake_ds {
-    my ( $self, $domain ) = @_;
-    my @data;
+    my ( $self ) = @_;
 
     foreach my $str ( @{ $self->ds } ) {
         if ( not $str =~ /$DS_RE/g ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -897,7 +897,6 @@ sub check_fake_delegation {
     }
 
     return;
-
 }
 
 sub check_fake_ds {
@@ -905,7 +904,6 @@ sub check_fake_ds {
     my @data;
 
     foreach my $str ( @{ $self->ds } ) {
-
         if ( not $str =~ /$DS_RE/g ) {
             say STDERR __( "--ds ds data must be in the form \"keytag,algorithm,type,digest\"");
             exit( 1 );
@@ -914,6 +912,7 @@ sub check_fake_ds {
 
     return;
 }
+
 sub add_fake_delegation {
     my ( $self, $domain ) = @_;
     my @ns_with_no_ip;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -904,7 +904,7 @@ sub check_fake_ds {
 
     foreach my $str ( @{ $self->ds } ) {
         unless ( $str =~ /$DS_RE/ ) {
-            say STDERR __( "--ds ds data must be in the form \"keytag,algorithm,type,digest\"");
+            say STDERR __( "--ds ds data must be in the form \"keytag,algorithm,type,digest\". E.g. space is not permitted anywhere in the string.");
             exit( 1 );
         }
     }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -908,7 +908,7 @@ sub check_fake_ds {
     my ( $self ) = @_;
 
     foreach my $str ( @{ $self->ds } ) {
-        if ( not $str =~ /$DS_RE/g ) {
+        unless ( $str =~ /$DS_RE/ ) {
             say STDERR __( "--ds ds data must be in the form \"keytag,algorithm,type,digest\"");
             exit( 1 );
         }


### PR DESCRIPTION
## Purpose

This separate CLI errors from Engine errors.
Errors on CLI argument are catch before displaying the header.

## Context

Fixes #358 

## Changes

I have split CLI argument verification from Engine settings.

I have also add regex validation for '--ds' arguments

## How to test this PR

Stress test zonemaster-cli with various '--ns' and '--ds' arguments.
Errors from command line input validation must be display **before** any header.
Errors from the Engine must be formatted correctly **after** the header.

here some example to cmd to run:
```
zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1.zonemaster.net'
zonemaster-cli --show-testcase  example.fr --ns 'ns1.zonemaster..fr.'
zonemaster-cli --show-testcase  example.fr --ns 'ns1.zonemaster.fr/542.0.0.1'
zonemaster-cli --show-testcase  example.fr --ns '/215.4.6.1'
zonemaster-cli --show-testcase afnic.fr --ds "32674 13 2 12CCEEFE3ECD007C"
zonemaster-cli --show-testcase afnic.fr --ds "32674,13,2,NOTHEXADECIMAL"
```

