### PR TITLE
Improved test coverage

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,6 +28,11 @@ requires(
     'Zonemaster::Engine' => 6.000000,  # v6.0.0
 );
 
+test_requires(
+    'JSON::Validator'   => 0,
+    'Test::Differences' => 0,
+);
+
 # Make all platforms include inc/Module/Install/External.pm
 requires_external_bin 'find';
 if ($^O eq "freebsd") {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -251,13 +251,7 @@ has 'progress' => (
 has 'encoding' => (
     is            => 'ro',
     isa           => 'Str',
-    default       => sub {
-        my $locale = $ENV{LC_CTYPE} // 'C';
-        my ( $e ) = $locale =~ m|\.(.*)$|;
-        $e //= 'UTF-8';
-        return $e;
-    },
-    documentation => __( 'Name of the character encoding used for command line arguments' ),
+    documentation => __( 'Deprecated: Simply remove it from your usage. It is ignored.' ),
 );
 
 has 'nstimes' => (
@@ -349,6 +343,10 @@ sub run {
     if ( $self->json_stream and not $self->json and grep( /^--no-?json$/, @{ $self->ARGV } ) ) {
         say STDERR __( "Error: --json-stream and --no-json can't be used together." );
         return $EXIT_USAGE_ERROR;
+    }
+
+    if ( $self->encoding ) {
+        say STDERR __( "Warning: deprecated --encoding, simply remove it from your usage." );
     }
 
     if ( defined $self->json_translate ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -18,15 +18,14 @@ use Moose;
 with 'MooseX::Getopt::GLD' => { getopt_conf => [ 'pass_through' ] };
 
 use Encode;
-use Readonly;
 use File::Slurp;
 use JSON::XS;
 use List::Util qw[max uniq];
+use Net::IP::XS;
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
+use Readonly;
 use Scalar::Util qw[blessed];
 use Try::Tiny;
-use Net::IP::XS;
-
 use Zonemaster::LDNS;
 use Zonemaster::Engine;
 use Zonemaster::Engine::Exception;

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -244,7 +244,6 @@ has 'count' => (
 has 'progress' => (
     is            => 'ro',
     isa           => 'Bool',
-    default       => !!( -t STDOUT ),
     documentation => __( 'Boolean flag for activity indicator. Defaults to on if STDOUT is a tty, off if it is not. Disable with --no-progress.' ),
 );
 
@@ -369,6 +368,8 @@ sub run {
     my $fh_diag = ( $self->json or $self->raw or $self->dump_profile )
       ? *STDERR     # Structured output mode (e.g. JSON)
       : *STDOUT;    # Human readable output mode
+
+    my $show_progress = $self->progress // !!-t STDOUT && !$self->json && !$self->raw;
 
     if ( $self->profile ) {
         say $fh_diag __x( "Loading profile from {path}.", path => $self->profile );
@@ -556,7 +557,7 @@ sub run {
         sub {
             my ( $entry ) = @_;
 
-            $self->print_spinner() if $fh_diag eq *STDOUT;
+            print_spinner() if $show_progress;
 
             $counter{ uc $entry->level } += 1;
 
@@ -925,11 +926,9 @@ sub print_versions {
 my @spinner_strings = ( '  | ', '  / ', '  - ', '  \\ ' );
 
 sub print_spinner {
-    my ( $self ) = @_;
-
     state $counter = 0;
 
-    printf "%s\r", $spinner_strings[ $counter++ % 4 ] if $self->progress;
+    printf "%s\r", $spinner_strings[ $counter++ % 4 ];
 
     return;
 }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -658,13 +658,21 @@ sub run {
 
     if ( defined $self->hints ) {
         my $hints_data;
+        my $error = undef;
         try {
-            my $hints_text = read_file( $self->hints );
+            my $hints_text = read_file( $self->hints ) // die "read_file failed\n";
+            local $SIG{__WARN__} = \&die;
             $hints_data = parse_hints( $hints_text )
         }
         catch {
-            die "Error loading hints file: $_";
+            $error = $_;
+        };
+
+        if ( defined $error ) {
+            print STDERR __x( "Error loading hints file: {message}", message => $error );
+            return $EXIT_USAGE_ERROR;
         }
+
         Zonemaster::Engine::Recursor->remove_fake_addresses( '.' );
         Zonemaster::Engine::Recursor->add_fake_addresses( '.', $hints_data );
     }

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -246,12 +246,7 @@ Default: on (if the process' standard output is a TTY)
 
 =item --encoding=ENCODING
 
-Specify the character encoding that is used for command line arguments. This
-will be used to convert non-ASCII names to IDNA format, on which the testing
-suite will then be run.
-
-The default value will be taken from the C<LC_CTYPE> environment variable if
-possible, and set to UTF-8 if not.
+Deprecated: Simply remove it from your usage. It is ignored.
 
 =item --nstimes
 

--- a/t/usage.t
+++ b/t/usage.t
@@ -237,35 +237,35 @@ do {
     check_success 'override net.ipv4', [ '--dump-profile', '--profile=t/usage.profile', '--ipv4' ], sub {
         my ( $profile ) = parse_json_stream( $_[0] );
 
-        my $value = $profile->{net}{ipv4} // '<missing>';
+        my $ipv4 = exists $profile->{net}{ipv4} ? ( $profile->{net}{ipv4} ? '1' : '0' ) : '<missing>';
 
-        return $value eq '1';
+        return $ipv4 eq '1';
     };
 
     check_success 'override net.ipv6', [ '--dump-profile', '--profile=t/usage.profile', '--ipv6' ], sub {
         my ( $profile ) = parse_json_stream( $_[0] );
 
-        my $value = $profile->{net}{ipv6} // '';
+        my $ipv6 = exists $profile->{net}{ipv6} ? ( $profile->{net}{ipv6} ? '1' : '0' ) : '<missing>';
 
-        return $value eq '1';
+        return $ipv6 eq '1';
     };
 
     check_success 'override resolver.source4',
       [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr4', '192.0.2.2' ], sub {
         my ( $profile ) = parse_json_stream( $_[0] );
 
-        my $value = $profile->{resolver}{source4} // '';
+        my $source4 = $profile->{resolver}{source4} // '<missing>';
 
-        return $value eq '192.0.2.2';
+        return $source4 eq '192.0.2.2';
       };
 
     check_success 'override resolver.source6',
       [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr6', '2001:db8::2' ], sub {
         my ( $profile ) = parse_json_stream( $_[0] );
 
-        my $value = $profile->{resolver}{source6} // '';
+        my $source6 = $profile->{resolver}{source6} // '<missing>';
 
-        return $value eq '2001:db8::2';
+        return $source6 eq '2001:db8::2';
       };
 };
 

--- a/t/usage.t
+++ b/t/usage.t
@@ -449,6 +449,12 @@ do {
     check_usage_error '--json-stream and --no-json', [ '--json-stream', '--no-json', 'example.' ],
       qr{can't be used together}i;
 
+    check_usage_error 'Bad --hints (directory)', [ '--hints', '/', 'example.' ],
+      qr{error loading hints file}i;
+
+    check_usage_error 'Bad --hints (syntax)', [ '--hints', 't/usage.t', 'example.' ],
+      qr{error loading hints file}i;
+
     check_success '--version', ['--version'], qr{
         ^\QZonemaster-CLI version\E .*
         ^\QZonemaster-Engine version\E .*

--- a/t/usage.t
+++ b/t/usage.t
@@ -29,6 +29,12 @@ Readonly::Scalar my $PATH_WRAPPER            => catfile( dirname( __FILE__ ), 'u
 Readonly::Scalar my $PATH_NORMAL_DATAFILE    => catfile( dirname( __FILE__ ), 'usage.normal.data' );
 Readonly::Scalar my $PATH_FAKE_DATA_DATAFILE => catfile( dirname( __FILE__ ), 'usage.fake-data.data' );
 Readonly::Scalar my $PATH_FAKE_ROOT_DATAFILE => catfile( dirname( __FILE__ ), 'usage.fake-root.data' );
+Readonly::Array my @PERL => do {
+    # Detect whether Devel::Cover is running
+    my $is_covering = !!( eval 'Devel::Cover::get_coverage()' );
+    note $is_covering ? 'Devel::Cover running' : 'Devel::Cover not covering';
+    ( $^X, $is_covering ? ( '-MDevel::Cover=-silent,1' ) : () )
+};
 
 # MUTABLE GLOBAL VARIABLES
 
@@ -127,7 +133,7 @@ sub has_locale {
 sub _run_zonemaster_cli {
     my ( $datafile, @args ) = @_;
 
-    my @cmd = ( $PATH_WRAPPER );
+    my @cmd = ( @PERL, $PATH_WRAPPER );
     if ( defined $datafile ) {
         if ( $ENV{ZONEMASTER_RECORD} ) {
             push @cmd, '--record';

--- a/t/usage.t
+++ b/t/usage.t
@@ -7,8 +7,9 @@ use Test::More;
 use Config '%Config';
 use Encode                qw( decode_utf8 );
 use File::Basename        qw( dirname );
-use File::Slurp           qw( write_file );
+use File::Slurp           qw( read_file write_file );
 use File::Spec::Functions qw( catfile );
+use File::Temp            qw( tempdir );
 use IPC::Open3;
 use JSON::XS;
 use POSIX;
@@ -168,114 +169,6 @@ sub _run_zonemaster_cli {
 # TESTS
 
 do {
-    local $test_datafile = undef;
-    note "TESTS USING NO NETWORK AND NO FILE FOR RECORDED DATA:";
-
-    check_usage_error 'no domain', [], qr{must give the name of a domain to test}i;
-
-    check_usage_error 'too many domains', [ 'example.com', 'example.net' ],
-      qr{only one domain can be given for testing}i;
-
-    check_usage_error 'invalid domain', ['!%~&'], qr{character not permitted}i;
-
-    check_usage_error 'unrecognized option', ['--foobar'], qr{unknown option}i;
-
-    check_usage_error '--test BAD_MODULE', [ '--test', '!%~&', 'example.' ], qr{invalid input}i;
-
-    check_usage_error '--test UNKNOWN_MODULE/TESTCASE', [ '--test', 'foobar/foobar01', 'example.' ],
-      qr{unrecognized test module}i;
-
-    check_usage_error '--test MODULE/UNKNOWN_TESTCASE', [ '--test', 'basic/foobar01', 'example.' ],
-      qr{unrecognized test case}i;
-
-    check_usage_error '--test MODULE//TESTCASE', [ '--test', 'basic//basic01', 'example.' ], qr{invalid input}i;
-
-    check_usage_error '--ns BAD_NAME', [ '--ns', '!%~&', 'example.' ], qr{invalid name}i;
-
-    check_usage_error '--ns NAME//IP', [ '--ns', 'ns1.example//192.0.2.1', 'example.' ], qr{--ns}i;
-
-    check_usage_error '--ns NAME/BAD_IP', [ '--ns', 'ns1.example/foobar', 'example.' ], qr{invalid ip address}i;
-
-    check_usage_error '--sourceaddr4', [ '--sourceaddr4', 'foobar', 'example.' ], qr{invalid value}i;
-
-    check_usage_error '--sourceaddr6', [ '--sourceaddr6', 'foobar', 'example.' ], qr{invalid value}i;
-
-    check_usage_error '--level BAD_LEVEL', [ '--level', 'foobar', 'example.' ], qr{--level}i;
-
-    check_usage_error '--stop-level BAD_LEVEL', [ '--stop-level', 'foobar', 'example.' ],
-      qr{failed to recognize stop level}i;
-
-    check_usage_error '--json-stream and --no-json', [ '--json-stream', '--no-json', 'example.' ],
-      qr{can't be used together}i;
-
-    check_success '--version', ['--version'], qr{
-        ^\QZonemaster-CLI version\E .*
-        ^\QZonemaster-Engine version\E .*
-        ^\QZonemaster-LDNS version\E .*
-        ^\QNL NetLabs LDNS version\E .*
-    }msx;
-
-    check_success '--list-tests', ['--list-tests'], qr{
-        Basic
-        .*
-        basic01
-    }msx;
-
-    check_success '--dump-profile', ['--dump-profile'], qr{
-        "no_network"
-    }msx;
-
-    check_success 'override profile', [ '--dump-profile', '--profile=t/usage.profile' ], sub {
-        my ( $profile ) = parse_json_stream( $_[0] );
-
-        my $ipv4    = exists $profile->{net}{ipv4} ? ( $profile->{net}{ipv4} ? '1' : '0' ) : '<missing>';
-        my $ipv6    = exists $profile->{net}{ipv6} ? ( $profile->{net}{ipv6} ? '1' : '0' ) : '<missing>';
-        my $source4 = $profile->{resolver}{source4} // '<missing>';
-        my $source6 = $profile->{resolver}{source6} // '<missing>';
-
-        return
-             ( $ipv4 eq '0' )
-          && ( $ipv6 eq '0' )
-          && ( $source4 eq '192.0.2.1' )
-          && ( $source6 eq '2001:db8::1' );
-    };
-
-    check_success 'override net.ipv4', [ '--dump-profile', '--profile=t/usage.profile', '--ipv4' ], sub {
-        my ( $profile ) = parse_json_stream( $_[0] );
-
-        my $ipv4 = exists $profile->{net}{ipv4} ? ( $profile->{net}{ipv4} ? '1' : '0' ) : '<missing>';
-
-        return $ipv4 eq '1';
-    };
-
-    check_success 'override net.ipv6', [ '--dump-profile', '--profile=t/usage.profile', '--ipv6' ], sub {
-        my ( $profile ) = parse_json_stream( $_[0] );
-
-        my $ipv6 = exists $profile->{net}{ipv6} ? ( $profile->{net}{ipv6} ? '1' : '0' ) : '<missing>';
-
-        return $ipv6 eq '1';
-    };
-
-    check_success 'override resolver.source4',
-      [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr4', '192.0.2.2' ], sub {
-        my ( $profile ) = parse_json_stream( $_[0] );
-
-        my $source4 = $profile->{resolver}{source4} // '<missing>';
-
-        return $source4 eq '192.0.2.2';
-      };
-
-    check_success 'override resolver.source6',
-      [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr6', '2001:db8::2' ], sub {
-        my ( $profile ) = parse_json_stream( $_[0] );
-
-        my $source6 = $profile->{resolver}{source6} // '<missing>';
-
-        return $source6 eq '2001:db8::2';
-      };
-};
-
-do {
     local $test_datafile = $PATH_NORMAL_DATAFILE;
     note "TESTS USING $test_datafile FOR RECORDED DATA:";
 
@@ -294,12 +187,32 @@ do {
         Using .* \n
     }msx;
 
+    check_success 'normal table output, no optional fields, using underscore alias',
+      [ '--test=basic01', '--level=INFO', '--no-time', '--no-show_level', '.' ], qr{
+        ^
+        Message \n
+        =+ \n
+        Using .* \n
+    }msx;
+
     check_success 'normal table output, all fields',
       [ '--test=basic01', '--level=INFO', '--show-module', '--show-testcase', '.' ], qr{
         ^
         Seconds \s+ Level \s+ Module \s+ Testcase \s+ Message \n
         =+ \s =+ \s =+ \s =+ \s =+ \n
         \s* \Q0.00\E \s+ INFO \s+ System \s+ Unspecified \s+ Using .* \n
+    }msx;
+
+    check_success 'normal table output, all fields, using underscore aliases',
+      [ '--test=basic01', '--level=INFO', '--show_module', '--show_testcase', '.' ], qr{
+        ^
+        Seconds \s+ Level \s+ Module \s+ Testcase \s+ Message \n
+        =+ \s =+ \s =+ \s =+ \s =+ \n
+        \s* \Q0.00\E \s+ INFO \s+ System \s+ Unspecified \s+ Using .* \n
+    }msx;
+
+    check_success '--encoding', [ '--test=basic01', '--json', '--encoding', 'foobar', '.' ], qr{
+        \Q{"results":[]}\E
     }msx;
 
     check_success '--json', [ '--test=basic01', '--json', '.' ], qr{
@@ -319,13 +232,26 @@ do {
         return $found;
     };
 
+    check_success '--json_stream', [ '--test=basic01', '--json_stream', '--level=INFO', '.' ], sub {
+        my $found = 0;
+        for my $item ( parse_json_stream( $_[0] ) ) {
+            if ( $item->{tag} eq 'GLOBAL_VERSION' ) {
+                if ( $item->{message} !~ /^Using / ) {
+                    return 0;
+                }
+                $found = 1;
+            }
+        }
+        return $found;
+    };
+
     check_success '--raw', [ '--test=basic01', '--level=INFO', '--raw', '.' ], qr{
         ^
         \s* \Q0.00\E \s+ INFO \s+ GLOBAL_VERSION \s+ version= [v0-9.]+ \n
     }msx;
 
   SKIP: {
-        skip 'sv_SE.utf8 locale is unavailable', 3
+        skip 'sv_SE.utf8 locale is unavailable', 5
           if !has_locale( 'sv_SE.utf8' );
 
         check_success '--json-stream --no-raw',
@@ -342,7 +268,35 @@ do {
             return $found;
           };
 
+        check_success '--json-stream --json-translate',
+          [ '--test=basic01', '--json-stream', '--json-translate', '--locale=sv_SE.utf8', '--level=INFO', '.' ], sub {
+            my $found = 0;
+            for my $item ( parse_json_stream( decode_utf8( $_[0] ) ) ) {
+                if ( $item->{tag} eq 'GLOBAL_VERSION' ) {
+                    if ( $item->{message} !~ qr{^Använder } ) {
+                        return 0;
+                    }
+                    $found = 1;
+                }
+            }
+            return $found;
+          };
+
         check_success '--json-stream --no-raw --locale',
+          [ '--test=basic01', '--json-stream', '--no-raw', '--locale=sv_SE.utf8', '--level=INFO', '.' ], sub {
+            my $found = 0;
+            for my $item ( parse_json_stream( decode_utf8( $_[0] ) ) ) {
+                if ( $item->{tag} eq 'GLOBAL_VERSION' ) {
+                    if ( $item->{message} !~ qr{^Använder } ) {
+                        return 0;
+                    }
+                    $found = 1;
+                }
+            }
+            return $found;
+          };
+
+        check_success '--json-stream --json-translate --locale',
           [ '--test=basic01', '--json-stream', '--no-raw', '--locale=sv_SE.utf8', '--level=INFO', '.' ], sub {
             my $found = 0;
             for my $item ( parse_json_stream( decode_utf8( $_[0] ) ) ) {
@@ -405,6 +359,26 @@ do {
         return ( $stdout =~ qr{NOTICE .* WARNING}msx )
           && ( $stdout !~ qr{ERROR}m );
       };
+
+    check_success '--stop_level',
+      [
+        '--profile=t/usage.profile', '--ipv4', '--sourceaddr4',        '',
+        '--test=basic',              '--raw',  '--stop_level=warning', '.'
+      ],
+      sub {
+        my $stdout = $_[0];
+
+        return ( $stdout =~ qr{NOTICE .* WARNING}msx )
+          && ( $stdout !~ qr{ERROR}m );
+      };
+
+    my $tempdir  = tempdir( CLEANUP => 1 );
+    my $savefile = catfile( $tempdir, 'saved.data' );
+    check_success 'run command', [ "--save=$savefile", '--test=basic01', '.' ], sub {
+        my @saved_lines    = read_file $savefile;
+        my @expected_lines = read_file $PATH_NORMAL_DATAFILE;
+        return scalar( @saved_lines ) == scalar( @expected_lines );
+    };
 };
 
 do {
@@ -432,6 +406,127 @@ do {
     note "TESTS USING $test_datafile FOR RECORDED DATA:";
 
     check_success '--hints', [ '--noipv6', '--raw', '--hints=t/usage.hints', 'example.' ], qr{CANNOT_CONTINUE}i;
+};
+
+do {
+    local $test_datafile = undef;
+    note "TESTS USING NO NETWORK AND NO FILE FOR RECORDED DATA:";
+
+    check_usage_error 'no domain', [], qr{must give the name of a domain to test}i;
+
+    check_usage_error 'too many domains', [ 'example.com', 'example.net' ],
+      qr{only one domain can be given for testing}i;
+
+    check_usage_error 'invalid domain', ['!%~&'], qr{character not permitted}i;
+
+    check_usage_error 'unrecognized option', ['--foobar'], qr{unknown option}i;
+
+    check_usage_error '--test BAD_MODULE', [ '--test', '!%~&', 'example.' ], qr{invalid input}i;
+
+    check_usage_error '--test UNKNOWN_MODULE/TESTCASE', [ '--test', 'foobar/foobar01', 'example.' ],
+      qr{unrecognized test module}i;
+
+    check_usage_error '--test MODULE/UNKNOWN_TESTCASE', [ '--test', 'basic/foobar01', 'example.' ],
+      qr{unrecognized test case}i;
+
+    check_usage_error '--test MODULE//TESTCASE', [ '--test', 'basic//basic01', 'example.' ], qr{invalid input}i;
+
+    check_usage_error '--ns BAD_NAME', [ '--ns', '!%~&', 'example.' ], qr{invalid name}i;
+
+    check_usage_error '--ns NAME//IP', [ '--ns', 'ns1.example//192.0.2.1', 'example.' ], qr{--ns}i;
+
+    check_usage_error '--ns NAME/BAD_IP', [ '--ns', 'ns1.example/foobar', 'example.' ], qr{invalid ip address}i;
+
+    check_usage_error '--sourceaddr4', [ '--sourceaddr4', 'foobar', 'example.' ], qr{invalid value}i;
+
+    check_usage_error '--sourceaddr6', [ '--sourceaddr6', 'foobar', 'example.' ], qr{invalid value}i;
+
+    check_usage_error '--level BAD_LEVEL', [ '--level', 'foobar', 'example.' ], qr{--level}i;
+
+    check_usage_error '--stop-level BAD_LEVEL', [ '--stop-level', 'foobar', 'example.' ],
+      qr{failed to recognize stop level}i;
+
+    check_usage_error '--json-stream and --no-json', [ '--json-stream', '--no-json', 'example.' ],
+      qr{can't be used together}i;
+
+    check_success '--version', ['--version'], qr{
+        ^\QZonemaster-CLI version\E .*
+        ^\QZonemaster-Engine version\E .*
+        ^\QZonemaster-LDNS version\E .*
+        ^\QNL NetLabs LDNS version\E .*
+    }msx;
+
+    check_success '--list-tests', ['--list-tests'], qr{
+        Basic
+        .*
+        basic01
+    }msx;
+
+    check_success '--list_tests', ['--list_tests'], qr{
+        Basic
+        .*
+        basic01
+    }msx;
+
+    check_success '--dump-profile', ['--dump-profile'], qr{
+        "no_network"
+    }msx;
+
+    check_success '--dump_profile', ['--dump_profile'], qr{
+        "no_network"
+    }msx;
+
+    check_success 'override profile', [ '--dump-profile', '--profile=t/usage.profile' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        my $ipv4    = exists $profile->{net}{ipv4} ? ( $profile->{net}{ipv4} ? '1' : '0' ) : '<missing>';
+        my $ipv6    = exists $profile->{net}{ipv6} ? ( $profile->{net}{ipv6} ? '1' : '0' ) : '<missing>';
+        my $source4 = $profile->{resolver}{source4} // '<missing>';
+        my $source6 = $profile->{resolver}{source6} // '<missing>';
+
+        return
+             ( $ipv4 eq '0' )
+          && ( $ipv6 eq '0' )
+          && ( $source4 eq '192.0.2.1' )
+          && ( $source6 eq '2001:db8::1' );
+    };
+
+    check_success 'override net.ipv4', [ '--dump-profile', '--profile=t/usage.profile', '--ipv4' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        my $ipv4 = exists $profile->{net}{ipv4} ? ( $profile->{net}{ipv4} ? '1' : '0' ) : '<missing>';
+
+        return $ipv4 eq '1';
+    };
+
+    check_success 'override net.ipv6', [ '--dump-profile', '--profile=t/usage.profile', '--ipv6' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        my $ipv6 = exists $profile->{net}{ipv6} ? ( $profile->{net}{ipv6} ? '1' : '0' ) : '<missing>';
+
+        return $ipv6 eq '1';
+    };
+
+    check_success 'override resolver.source4',
+      [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr4', '192.0.2.2' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        my $source4 = $profile->{resolver}{source4} // '<missing>';
+
+        return $source4 eq '192.0.2.2';
+      };
+
+    check_success 'override resolver.source6',
+      [ '--dump-profile', '--profile=t/usage.profile', '--sourceaddr6', '2001:db8::2' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        my $source6 = $profile->{resolver}{source6} // '<missing>';
+
+        return $source6 eq '2001:db8::2';
+      };
+
+    check_success '--restore', [ "--restore=$PATH_NORMAL_DATAFILE", '--test=basic01', '--level=INFO', '--raw', '.' ],
+      qr{B01_CHILD_FOUND};
 };
 
 done_testing;


### PR DESCRIPTION
## Purpose

### Scope

This PR concerns itself with validation and dispatching of user-provided command line options to zonemaster-cli.

Limitations:

* The actual implementations of the options are only within scope here to the extent that proper dispatching can be determined. Any other problems with option implementations are deferred to separate issues.
* Details in how command line arguments are parsed are out of scope.
* The --progress option is out of scope.

### Goal

This PR aims to establish a sufficient regression testing suite for the stated scope. It would be great if we didn't need to perform any manual testing for this particular aspect of the application when switching out the command line parsing library.

## Context

As part of #68 we plan to drop our dependency on Moose and MooseX::Getopt::GLD. That will affect every command line option in zonemaster-cli.

## Changes

Fixes the handling of invalid --hints argument.

New tests are added for options and option combinations:

 * --restore
 * --save
 * --json-translate
 * --encoding
 * --count --raw
 * --count --json
 * --count --json-stream
 * --elapsed --raw
 * --elapsed --json
 * --elapsed --json-stream
 * --nstimes --raw
 * --nstimes --json
 * --nstimes --json-stream
 * Underscore option aliases

To help finding gaps in test coverage I added support for Devel::Cover in usage.t.

This PR also includes some cleanups.

## How to test this PR

Unit test should pass.

## Special considerations when reviewing this PR

1. Are there any options or combinations that deserve automatic tests but doesn't have any?
2. Do any options or combinations deserve more thorough automatic tests?