### PR TITLE
Harmonize usage documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,6 @@ before_install:
   # Zonemaster LDNS needs a newer version of Module::Install
 - cpan-install Module::Install Module::Install::XSUtil
 
-  # Moose installed from OS package depends on a newer version of Devel::OverloadInfo
-- cpan-install Devel::OverloadInfo Moose MooseX::Getopt
-
   # IO::Socket::INET6 can't find Socket6 installed from OS package
 - cpan-install Socket6 IO::Socket::INET6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,10 @@
 FROM zonemaster/engine:local as build
 
 RUN apk add --no-cache \
-    build-base \
     make \
     perl-app-cpanminus \
-    perl-cpan-meta-check \
-    perl-data-dump \
-    perl-dev \
-    perl-doc \
     perl-json-xs \
-    perl-lwp-protocol-https \
-    perl-module-build \
-    perl-module-build-tiny \
-    perl-module-install \
-    perl-moose \
-    perl-namespace-autoclean \
-    perl-params-validate \
-    perl-path-tiny \
-    perl-test-deep \
-    perl-test-needs \
- && cpanm --no-wget --from https://cpan.metacpan.org/ \
-    MooseX::Getopt
+    perl-try-tiny
 
 ARG version
 
@@ -32,10 +16,8 @@ RUN cpanm --no-wget \
 FROM zonemaster/engine:local
 
 RUN apk add --no-cache \
-    perl-namespace-autoclean \
-    perl-params-validate \
     perl-json-xs \
-    perl-moose
+    perl-try-tiny
 
 COPY --from=build /usr/local/bin/zonemaster-cli /usr/local/bin/zonemaster-cli
 # Include all the Perl modules we built

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,6 @@ requires(
     'Net::IP::XS'        => 0,
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
-    'MooseX::Getopt'     => 0,
     'Try::Tiny'          => 0,
     'Zonemaster::LDNS'   => 4.000002,  # v4.0.2
     'Zonemaster::Engine' => 6.000000,  # v6.0.0

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -1,7 +1,8 @@
 # Brief help module to define the exception we use for early exits.
 package Zonemaster::Engine::Exception::NormalExit;
-use Moose;
-extends 'Zonemaster::Engine::Exception';
+use 5.014002;
+use warnings;
+use parent 'Zonemaster::Engine::Exception';
 
 # The actual interesting module.
 package Zonemaster::CLI;
@@ -14,14 +15,14 @@ use warnings;
 use version; our $VERSION = version->declare( "v7.0.0" );
 
 use Locale::TextDomain 'Zonemaster-CLI';
-use Moose;
-with 'MooseX::Getopt::GLD' => { getopt_conf => [ 'pass_through' ] };
 
 use Encode;
 use File::Slurp;
+use Getopt::Long qw[GetOptionsFromArray];
 use JSON::XS;
 use List::Util qw[max uniq];
 use Net::IP::XS;
+use Pod::Usage;
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
 use Readonly;
 use Scalar::Util qw[blessed];
@@ -36,6 +37,7 @@ use Zonemaster::Engine::Util qw[parse_hints];
 
 our %numeric = Zonemaster::Engine::Logger::Entry->levels;
 our $JSON    = JSON::XS->new->allow_blessed->convert_blessed->canonical;
+our $SCRIPT  = $0;
 
 Readonly our $EXIT_SUCCESS       => 0;
 Readonly our $EXIT_GENERIC_ERROR => 1;
@@ -46,275 +48,121 @@ Readonly our $IPV6_RE => qr/^[0-9a-f:]*:[0-9a-f:]+(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9
 
 STDOUT->autoflush( 1 );
 
-has 'version' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    default       => 0,
-    required      => 0,
-    documentation => __( 'Print version information and exit.' ),
-);
+sub my_pod2usage {
+    my ( %opts ) = @_;
 
-has 'level' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    default       => 'NOTICE',
-    initializer   => sub {
-        my ( $self, $value, $set, $attr ) = @_;
-        $set->( uc $value );
-    },
-    documentation =>
-      __( 'The minimum severity level to display. Must be one of CRITICAL, ERROR, WARNING, NOTICE, INFO or DEBUG.' ),
-);
+    pod2usage(
+        -input    => $SCRIPT,
+        -output   => $opts{output},
+        -verbose  => $opts{verbosity},
+        -exitcode => 'NOEXIT',
+    );
 
-has 'locale' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __( 'The locale to use for messages translation.' ),
-);
-
-has 'json' => (
-    is            => 'rw',
-    isa           => 'Bool',
-    default       => 0,
-    documentation => __( 'Flag indicating if output should be in JSON or not.' ),
-);
-
-has 'json_stream' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    default       => 0,
-    cmd_aliases   => 'json_stream',
-    cmd_flag      => 'json-stream',
-    documentation => __( 'Flag indicating if output should be streaming JSON or not.' ),
-);
-
-has 'json_translate' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    cmd_aliases   => 'json_translate',
-    cmd_flag      => 'json-translate',
-    documentation => __( 'Deprecated. Flag indicating if JSON output should include the translated message of the tag or not.' ),
-);
-
-has 'raw' => (
-    is            => 'rw',
-    isa           => 'Bool',
-    documentation => __( 'Flag indicating if output should be translated to human language or dumped raw.' ),
-);
-
-has 'time' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    documentation => __( 'Print timestamp on entries.' ),
-    default       => 1,
-);
-
-has 'show_level' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    cmd_aliases   => 'show_level',
-    cmd_flag      => 'show-level',
-    documentation => __( 'Print level on entries.' ),
-    default       => 1,
-);
-
-has 'show_module' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    cmd_aliases   => 'show_module',
-    cmd_flag      => 'show-module',
-    documentation => __( 'Print the name of the module on entries.' ),
-    default       => 0,
-);
-
-has 'show_testcase' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    cmd_aliases   => 'show_testcase',
-    cmd_flag      => 'show-testcase',
-    documentation => __( 'Print the name of the test case on entries.' ),
-    default       => 0,
-);
-
-has 'ns' => (
-    is            => 'ro',
-    isa           => 'ArrayRef',
-    documentation => __( 'A name/ip string giving a nameserver for undelegated tests, or just a name which will be looked up for IP addresses. Can be given multiple times.' ),
-);
-
-has 'hints' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __( 'Name of a root hints file to override the defaults.' ),
-);
-
-has 'save' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __( 'Name of a file to save DNS data to after running tests.' ),
-);
-
-has 'restore' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __( 'Name of a file to restore DNS data from before running test.' ),
-);
-
-has 'ipv4' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    documentation =>
-      __( 'Flag to permit or deny queries being sent via IPv4. --ipv4 permits IPv4 traffic, --no-ipv4 forbids it.' ),
-);
-
-has 'ipv6' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    documentation =>
-      __( 'Flag to permit or deny queries being sent via IPv6. --ipv6 permits IPv6 traffic, --no-ipv6 forbids it.' ),
-);
-
-has 'list_tests' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    default       => 0,
-    cmd_aliases   => 'list_tests',
-    cmd_flag      => 'list-tests',
-    documentation => __( 'Instead of running a test, list all available tests.' ),
-);
-
-has 'test' => (
-    is            => 'ro',
-    isa           => 'ArrayRef',
-    required      => 0,
-    documentation => __(
-'Specify test case to be run. Should be the case-insensitive name of a test module (e.g. "Delegation") and/or a test case (e.g. "Delegation/delegation01" or "delegation01"). This switch can be repeated.'
-    )
-);
-
-has 'stop_level' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    initializer   => sub {
-        my ( $self, $value, $set, $attr ) = @_;
-        $set->( uc $value );
-    },
-    cmd_aliases   => 'stop_level',
-    cmd_flag      => 'stop-level',
-    documentation => __(
-'As soon as a message at this level or higher is logged, execution will stop. Must be one of CRITICAL, ERROR, WARNING, NOTICE, INFO or DEBUG.'
-    )
-);
-
-has 'profile' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __( 'Name of profile file to load. (DEFAULT)' ),
-);
-
-has 'ds' => (
-    is            => 'ro',
-    isa           => 'ArrayRef[Str]',
-    required      => 0,
-    documentation => __( 'Strings with DS data on the form "keytag,algorithm,type,digest"' ),
-);
-
-has 'count' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    required      => 0,
-    documentation => __( 'Print a count of the number of messages at each level' ),
-);
-
-has 'progress' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    documentation => __( 'Boolean flag for activity indicator. Defaults to on if STDOUT is a tty, off if it is not. Disable with --no-progress.' ),
-);
-
-has 'encoding' => (
-    is            => 'ro',
-    isa           => 'Str',
-    documentation => __( 'Deprecated: Simply remove it from your usage. It is ignored.' ),
-);
-
-has 'nstimes' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    required      => 0,
-    default       => 0,
-    documentation => __( 'At the end of a run, print a summary of the times (in milliseconds) the zone\'s name servers took to answer.' ),
-);
-
-has 'dump_profile' => (
-    traits        => [ 'Getopt' ],
-    is            => 'ro',
-    isa           => 'Bool',
-    required      => 0,
-    default       => 0,
-    cmd_aliases   => 'dump_profile',
-    cmd_flag      => 'dump-profile',
-    documentation => __( 'Print the effective profile used in JSON format, then exit.' ),
-);
-
-has 'sourceaddr4' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __(
-            'Source IPv4 address used to send queries. '
-          . 'Setting an IPv4 address not correctly configured on a local network interface fails silently.'
-    ),
-);
-
-has 'sourceaddr6' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __(
-            'Source IPv6 address used to send queries. '
-          . 'Setting an IPv6 address not correctly configured on a local network interface fails silently.'
-    ),
-);
-
-has 'elapsed' => (
-    is            => 'ro',
-    isa           => 'Bool',
-    required      => 0,
-    default       => 0,
-    documentation => __( 'Print elapsed time (in seconds) at end of run.' ),
-);
+    return;
+}
 
 # Returns an integer representing an OS exit status.
 sub run {
-    my ( $self ) = @_;
+    my ( $class, @argv ) = @_;
+
+    my $opt_count        = 0;
+    my @opt_ds           = ();
+    my $opt_dump_profile = 0;
+    my $opt_elapsed      = 0;
+    my $opt_encoding     = undef;
+    my $opt_help         = 0;
+    my $opt_hints;
+    my $opt_ipv4           = undef;
+    my $opt_ipv6           = undef;
+    my $opt_json           = undef;
+    my $opt_json_stream    = 0;
+    my $opt_json_translate = undef;
+    my $opt_level          = 'NOTICE';
+    my $opt_list_tests     = 0;
+    my $opt_locale         = undef;
+    my @opt_ns             = ();
+    my $opt_nstimes        = 0;
+    my $opt_profile;
+    my $opt_progress = undef;
+    my $opt_raw;
+    my $opt_restore;
+    my $opt_save;
+    my $opt_show_level    = 1;
+    my $opt_show_module   = 0;
+    my $opt_show_testcase = 0;
+    my $opt_sourceaddr4;
+    my $opt_sourceaddr6;
+    my $opt_stop_level = 'CRITICAL';
+    my @opt_test       = ();
+    my $opt_time       = 1;
+    my $opt_version    = 0;
+
+    {
+        local $SIG{__WARN__} = sub { print STDERR $_[0] };
+
+        GetOptionsFromArray(
+            \@argv,
+            'count!'          => \$opt_count,
+            'ds=s'            => \@opt_ds,
+            'dump-profile!'   => \$opt_dump_profile,
+            'dump_profile!'   => \$opt_dump_profile,
+            'elapsed!'        => \$opt_elapsed,
+            'encoding=s'      => \$opt_encoding,
+            'hints=s'         => \$opt_hints,
+            'help!'           => \$opt_help,
+            'ipv4!'           => \$opt_ipv4,
+            'ipv6!'           => \$opt_ipv6,
+            'json!'           => \$opt_json,
+            'json-stream!'    => \$opt_json_stream,
+            'json_stream!'    => \$opt_json_stream,
+            'json-translate!' => \$opt_json_translate,
+            'json_translate!' => \$opt_json_translate,
+            'level=s'         => \$opt_level,
+            'list-tests!'     => \$opt_list_tests,
+            'list_tests!'     => \$opt_list_tests,
+            'locale=s'        => \$opt_locale,
+            'ns=s'            => \@opt_ns,
+            'nstimes!'        => \$opt_nstimes,
+            'profile=s'       => \$opt_profile,
+            'progress!'       => \$opt_progress,
+            'raw!'            => \$opt_raw,
+            'restore=s'       => \$opt_restore,
+            'save=s'          => \$opt_save,
+            'show-level!'     => \$opt_show_level,
+            'show_level!'     => \$opt_show_level,
+            'show-module!'    => \$opt_show_module,
+            'show_module!'    => \$opt_show_module,
+            'show-testcase!'  => \$opt_show_testcase,
+            'show_testcase!'  => \$opt_show_testcase,
+            'sourceaddr4=s'   => \$opt_sourceaddr4,
+            'sourceaddr6=s'   => \$opt_sourceaddr6,
+            'stop-level=s'    => \$opt_stop_level,
+            'stop_level=s'    => \$opt_stop_level,
+            'test=s'          => \@opt_test,
+            'time!'           => \$opt_time,
+            'version!'        => \$opt_version,
+        ) or do {
+            my_pod2usage( verbosity => 0, output => \*STDERR );
+            return 2;
+        };
+    }
+
+    if ( $opt_help ) {
+        my_pod2usage( verbosity => 1, output => \*STDOUT );
+        say "For more details and advanced options, see the full manual with `man zonemaster-cli`.";
+        return 0;
+    }
+
+    $opt_level      = uc $opt_level;
+    $opt_stop_level = uc $opt_stop_level;
+
     my @accumulator;
     my %counter;
     my $printed_something;
 
-    if ( grep /^-/, @{ $self->extra_argv } ) {
-        say STDERR "Unknown option: ", join( q{ }, grep /^-/, @{ $self->extra_argv } );
-        say STDERR "Run \"zonemaster-cli -h\" to get the valid options";
-        return $EXIT_USAGE_ERROR;
-    }
-
-    if ( $self->locale ) {
+    if ( $opt_locale ) {
         undef $ENV{LANGUAGE};
-        $ENV{LC_ALL} = $self->locale;
+        $ENV{LC_ALL} = $opt_locale;
     }
 
     # Set LC_MESSAGES and LC_CTYPE separately (https://www.gnu.org/software/gettext/manual/html_node/Triggering.html#Triggering)
@@ -327,31 +175,31 @@ sub run {
         $ENV{LC_ALL} || $ENV{LC_CTYPE};
     }
 
-    if ( $self->version ) {
+    if ( $opt_version ) {
         print_versions();
         return $EXIT_SUCCESS;
     }
 
-    if ( $self->list_tests ) {
+    if ( $opt_list_tests ) {
         print_test_list();
         return $EXIT_SUCCESS;
     }
 
     # errors and warnings
-    if ( $self->json_stream and not $self->json and grep( /^--no-?json$/, @{ $self->ARGV } ) ) {
+    if ( defined $opt_encoding ) {
+        say STDERR __( "Warning: deprecated --encoding, simply remove it from your usage." );
+    }
+
+    if ( $opt_json_stream and defined $opt_json and not $opt_json ) {
         say STDERR __( "Error: --json-stream and --no-json can't be used together." );
         return $EXIT_USAGE_ERROR;
     }
 
-    if ( $self->encoding ) {
-        say STDERR __( "Warning: deprecated --encoding, simply remove it from your usage." );
-    }
-
-    if ( defined $self->json_translate ) {
-        unless ( $self->json or $self->json_stream ) {
+    if ( defined $opt_json_translate ) {
+        unless ( $opt_json or $opt_json_stream ) {
             printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
         }
-        if ( $self->json_translate ) {
+        if ( $opt_json_translate ) {
             printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
         }
         else {
@@ -360,29 +208,29 @@ sub run {
     }
 
     # align values
-    $self->json( 1 ) if $self->json_stream;
-    $self->raw( $self->raw // ( defined $self->json_translate ? !$self->json_translate : 0 ) );
+    $opt_json = 1 if $opt_json_stream;
+    $opt_raw //= defined $opt_json_translate ? !$opt_json_translate : 0;
 
     # Filehandle for diagnostics output
-    my $fh_diag = ( $self->json or $self->raw or $self->dump_profile )
+    my $fh_diag = ( $opt_json or $opt_raw or $opt_dump_profile )
       ? *STDERR     # Structured output mode (e.g. JSON)
       : *STDOUT;    # Human readable output mode
 
-    my $show_progress = $self->progress // !!-t STDOUT && !$self->json && !$self->raw;
+    my $show_progress = $opt_progress // !!-t STDOUT && !$opt_json && !$opt_raw;
 
-    if ( $self->profile ) {
-        say $fh_diag __x( "Loading profile from {path}.", path => $self->profile );
-        my $json    = read_file( $self->profile );
+    if ( $opt_profile ) {
+        say $fh_diag __x( "Loading profile from {path}.", path => $opt_profile );
+        my $json    = read_file( $opt_profile );
         my $foo     = Zonemaster::Engine::Profile->from_json( $json );
         my $profile = Zonemaster::Engine::Profile->default;
         $profile->merge( $foo );
         Zonemaster::Engine::Profile->effective->merge( $profile );
     }
 
-    if ( defined $self->sourceaddr4 ) {
+    if ( defined $opt_sourceaddr4 ) {
         local $@;
         eval {
-            Zonemaster::Engine::Profile->effective->set( q{resolver.source4}, $self->sourceaddr4 );
+            Zonemaster::Engine::Profile->effective->set( q{resolver.source4}, $opt_sourceaddr4 );
             1;
         } or do {
             say STDERR __x( "Error: invalid value for --sourceaddr4: {reason}", reason => $@ );
@@ -390,10 +238,10 @@ sub run {
         };
     }
 
-    if ( defined $self->sourceaddr6 ) {
+    if ( defined $opt_sourceaddr6 ) {
         local $@;
         eval {
-            Zonemaster::Engine::Profile->effective->set( q{resolver.source6}, $self->sourceaddr6 );
+            Zonemaster::Engine::Profile->effective->set( q{resolver.source6}, $opt_sourceaddr6 );
             1;
         } or do {
             say STDERR __x( "Error: invalid value for --sourceaddr6: {reason}", reason => $@ );
@@ -402,12 +250,12 @@ sub run {
     }
 
     my @testing_suite;
-    if ( $self->test and @{ $self->test } > 0 ) {
+    if ( @opt_test ) {
         my %existing_tests = Zonemaster::Engine->all_methods;
         my @existing_test_modules = keys %existing_tests;
         my @existing_test_cases = map { @{ $existing_tests{$_} } } @existing_test_modules;
 
-        foreach my $t ( @{ $self->test } ) {
+        foreach my $t ( @opt_test ) {
             # There should be at most one slash character
             if ( $t =~ tr/\/// > 1 ) {
                 say STDERR __( "Error: Invalid input '$t' in --test. There must be at most one slash ('/') character.");
@@ -491,39 +339,39 @@ sub run {
 
     # These two must come after any profile from command line has been loaded
     # to make any IPv4/IPv6 option override the profile setting.
-    if ( defined ($self->ipv4) ) {
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, 0+$self->ipv4 );
+    if ( defined( $opt_ipv4 ) ) {
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, $opt_ipv4 );
     }
-    if ( defined ($self->ipv6) ) {
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, 0+$self->ipv6 );
+    if ( defined( $opt_ipv6 ) ) {
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, $opt_ipv6 );
     }
 
-    if ( $self->dump_profile ) {
+    if ( $opt_dump_profile ) {
         do_dump_profile();
         return $EXIT_SUCCESS;
     }
 
-    if ( $self->stop_level and not defined( $numeric{ $self->stop_level } ) ) {
-        say STDERR __x( "Failed to recognize stop level 'level'.", level => $self->stop_level );
+    if ( $opt_stop_level and not defined( $numeric{$opt_stop_level} ) ) {
+        say STDERR __x( "Failed to recognize stop level 'level'.", level => $opt_stop_level );
         return $EXIT_USAGE_ERROR;
     }
 
-    if ( not defined $numeric{ $self->level } ) {
+    if ( not defined $numeric{$opt_level} ) {
         say STDERR __( "--level must be one of CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, DEBUG2 or DEBUG3." );
         return $EXIT_USAGE_ERROR;
     }
 
     my $translator;
-    $translator = Zonemaster::Engine::Translator->new unless $self->raw;
-    $translator->locale( $self->locale ) if $translator and $self->locale;
+    $translator = Zonemaster::Engine::Translator->new unless $opt_raw;
+    $translator->locale( $opt_locale ) if $translator and $opt_locale;
 
-    if ( $self->restore ) {
-        Zonemaster::Engine->preload_cache( $self->restore );
+    if ( $opt_restore ) {
+        Zonemaster::Engine->preload_cache( $opt_restore );
     }
 
     my $level_width = 0;
     foreach ( keys %numeric ) {
-        if ( $numeric{ $self->level } <= $numeric{$_} ) {
+        if ( $numeric{$opt_level} <= $numeric{$_} ) {
             my $width_l10n = length( decode_utf8( translate_severity( $_ ) ) );
             $level_width = $width_l10n if $width_l10n > $level_width;
         }
@@ -560,46 +408,47 @@ sub run {
 
             $counter{ uc $entry->level } += 1;
 
-            if ( $numeric{ uc $entry->level } >= $numeric{ $self->level } ) {
+            if ( $numeric{ uc $entry->level } >= $numeric{$opt_level} ) {
                 $printed_something = 1;
 
-                if ( $self->json and $self->json_stream ) {
+                if ( $opt_json and $opt_json_stream ) {
                     my %r;
 
-                    $r{timestamp} = $entry->timestamp if $self->time;
-                    $r{module}    = $entry->module if $self->show_module;
-                    $r{testcase}  = $entry->testcase if $self->show_testcase;
+                    $r{timestamp} = $entry->timestamp if $opt_time;
+                    $r{module}    = $entry->module    if $opt_show_module;
+                    $r{testcase}  = $entry->testcase  if $opt_show_testcase;
                     $r{tag}       = $entry->tag;
-                    $r{level}     = $entry->level if $self->show_level;
-                    $r{args}      = $entry->args if $entry->args;
-                    $r{message}   = $translator->translate_tag( $entry ) unless $self->raw;
+                    $r{level}     = $entry->level if $opt_show_level;
+                    $r{args}      = $entry->args  if $entry->args;
+                    $r{message}   = $translator->translate_tag( $entry ) unless $opt_raw;
 
                     say $JSON->encode( \%r );
                 }
-                elsif ( $self->json and not $self->json_stream ) {
+                elsif ( $opt_json and not $opt_json_stream ) {
                     # Don't do anything
                 }
                 else {
                     my $prefix = q{};
-                    if ( $self->time ) {
+                    if ( $opt_time ) {
                         $prefix .= sprintf "%*.2f ", ${field_width{seconds}}, $entry->timestamp;
                     }
 
-                    if ( $self->show_level ) {
-                        $prefix .= $self->raw ? $entry->level : translate_severity( $entry->level );
-                        my $space_l10n = ${field_width{level}} - length( decode_utf8( translate_severity($entry->level) ) ) + 1;
+                    if ( $opt_show_level ) {
+                        $prefix .= $opt_raw ? $entry->level : translate_severity( $entry->level );
+                        my $space_l10n =
+                          ${ field_width { level } } - length( decode_utf8( translate_severity( $entry->level ) ) ) + 1;
                         $prefix .= ' ' x $space_l10n;
                     }
 
-                    if ( $self->show_module ) {
+                    if ( $opt_show_module ) {
                         $prefix .= sprintf "%-*s ", ${field_width{module}}, $entry->module;
                     }
 
-                    if ( $self->show_testcase ) {
+                    if ( $opt_show_testcase ) {
                         $prefix .= sprintf "%-*s ", ${field_width{testcase}}, $entry->testcase;
                     }
 
-                    if ( $self->raw ) {
+                    if ( $opt_raw ) {
                         $prefix .= $entry->tag;
 
                         my $message = $entry->argstr;
@@ -626,23 +475,23 @@ sub run {
                     }
                 }
             }
-            if ( $self->stop_level and $numeric{ uc $entry->level } >= $numeric{ $self->stop_level } ) {
+            if ( $opt_stop_level and $numeric{ uc $entry->level } >= $numeric{$opt_stop_level} ) {
                 die( Zonemaster::Engine::Exception::NormalExit->new( { message => "Saw message at level " . $entry->level } ) );
             }
         }
     );
 
-    if ( scalar @{ $self->extra_argv } > 1 ) {
-        say STDERR __( "Only one domain can be given for testing. Did you forget to prepend an option with '--<OPTION>'?" );
+    if ( @argv > 1 ) {
+        say STDERR __(
+            "Only one domain can be given for testing. Did you forget to prepend an option with '--<OPTION>'?" );
         return $EXIT_USAGE_ERROR;
     }
-
-    my ( $domain ) = @{ $self->extra_argv };
-
-    if ( !defined $domain ) {
+    elsif ( @argv < 1 ) {
         say STDERR __( "Must give the name of a domain to test." );
         return $EXIT_USAGE_ERROR;
     }
+
+    my ( $domain ) = @argv;
 
     ( my $errors, $domain ) = normalize_name( decode( 'utf8', $domain ) );
 
@@ -655,11 +504,11 @@ sub run {
         return $EXIT_USAGE_ERROR;
     }
 
-    if ( defined $self->hints ) {
+    if ( defined $opt_hints ) {
         my $hints_data;
         my $error = undef;
         try {
-            my $hints_text = read_file( $self->hints ) // die "read_file failed\n";
+            my $hints_text = read_file( $opt_hints ) // die "read_file failed\n";
             local $SIG{__WARN__} = \&die;
             $hints_data = parse_hints( $hints_text )
         }
@@ -676,10 +525,10 @@ sub run {
         Zonemaster::Engine::Recursor->add_fake_addresses( '.', $hints_data );
     }
 
-    if ( $self->ns and @{ $self->ns } > 0 ) {
+    if ( @opt_ns ) {
         local $@;
         eval {
-            $self->add_fake_delegation( $domain );
+            add_fake_delegation( $domain, @opt_ns );
             1;
         } or do {
             print STDERR $@;
@@ -687,42 +536,42 @@ sub run {
         };
     }
 
-    if ( $self->ds and @{ $self->ds } ) {
-        $self->add_fake_ds( $domain );
+    if ( @opt_ds ) {
+        add_fake_ds( $domain, @opt_ds );
     }
 
-    if ( $self->profile or $self->test ) {
+    if ( $opt_profile or @opt_test ) {
         # Separate initialization from main output in human readable output mode
         print "\n" if $fh_diag eq *STDOUT;
     }
 
-    if ( not $self->raw and not $self->json ) {
+    if ( not $opt_raw and not $opt_json ) {
         my $header = q{};
 
-        if ( $self->time ) {
+        if ( $opt_time ) {
             $header .= sprintf "%s%s ", $header_names{seconds}, " " x $remaining_space{seconds};
         }
-        if ( $self->show_level ) {
+        if ( $opt_show_level ) {
             $header .= sprintf "%s%s ", $header_names{level}, " " x $remaining_space{level};
         }
-        if ( $self->show_module ) {
+        if ( $opt_show_module ) {
             $header .= sprintf "%s%s ", $header_names{module}, " " x $remaining_space{module};
         }
-        if ( $self->show_testcase ) {
+        if ( $opt_show_testcase ) {
             $header .= sprintf "%s%s ", $header_names{testcase}, " " x $remaining_space{testcase};
         }
         $header .= sprintf "%s\n", $header_names{message};
 
-        if ( $self->time ) {
+        if ( $opt_time ) {
             $header .= sprintf "%s ", "=" x $field_width{seconds};
         }
-        if ( $self->show_level ) {
+        if ( $opt_show_level ) {
             $header .= sprintf "%s ", "=" x $field_width{level};
         }
-        if ( $self->show_module ) {
+        if ( $opt_show_module ) {
             $header .= sprintf "%s ", "=" x $field_width{module};
         }
-        if ( $self->show_testcase ) {
+        if ( $opt_show_testcase ) {
             $header .= sprintf "%s ", "=" x $field_width{testcase};
         }
         $header .= sprintf "%s\n", "=" x $field_width{message};
@@ -732,7 +581,7 @@ sub run {
 
     # Actually run tests!
     eval {
-        if ( $self->test and @{ $self->test } > 0 ) {
+        if ( @opt_test ) {
             foreach my $t ( @testing_suite ) {
                 # Either a module/method, or just a module
                 my ( $module, $method ) = split('/', $t);
@@ -749,7 +598,7 @@ sub run {
         }
     };
 
-    if ( not $self->raw and not $self->json ) {
+    if ( not $opt_raw and not $opt_json ) {
         if ( not $printed_something ) {
             say __( "Looks OK." );
         }
@@ -767,8 +616,8 @@ sub run {
 
     my $json_output = {};
 
-    if ( $self->count ) {
-        if ( $self->json ) {
+    if ( $opt_count ) {
+        if ( $opt_json ) {
             $json_output->{count} = {};
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
                 $json_output->{count}{$level} = $counter{$level};
@@ -783,11 +632,11 @@ sub run {
         }
     }
 
-    if ( $self->nstimes ) {
+    if ( $opt_nstimes ) {
         my $zone = Zonemaster::Engine->zone( $domain );
         my $max = max map { length( "$_" ) } ( @{ $zone->ns }, q{Server} );
 
-        if ( $self->json ) {
+        if ( $opt_json ) {
             my @times = ();
             foreach my $ns ( @{ $zone->ns } ) {
                 push @times, {
@@ -819,10 +668,10 @@ sub run {
         }
     }
 
-    if ($self->elapsed) {
+    if ( $opt_elapsed ) {
         my $last = Zonemaster::Engine->logger->entries->[-1];
 
-        if ( $self->json ) {
+        if ( $opt_json ) {
             $json_output->{elapsed} = $last->timestamp;
         }
         else {
@@ -830,19 +679,19 @@ sub run {
         }
     }
 
-    if ( $self->json and not $self->json_stream ) {
-        my $res = Zonemaster::Engine->logger->json( $self->level );
+    if ( $opt_json and not $opt_json_stream ) {
+        my $res = Zonemaster::Engine->logger->json( $opt_level );
         $res = $JSON->decode( $res );
         foreach ( @$res ) {
-            unless ( $self->raw ) {
+            unless ( $opt_raw ) {
                 my %e = %$_;
                 my $entry = Zonemaster::Engine::Logger::Entry->new( \%e );
                 $_->{message} = $translator->translate_tag( $entry );
             }
-            delete $_->{timestamp} unless $self->time;
-            delete $_->{level} unless $self->show_level;
-            delete $_->{module} unless $self->show_module;
-            delete $_->{testcase} unless $self->show_testcase;
+            delete $_->{timestamp} unless $opt_time;
+            delete $_->{level}     unless $opt_show_level;
+            delete $_->{module}    unless $opt_show_module;
+            delete $_->{testcase}  unless $opt_show_testcase;
         }
         $json_output->{results} = $res;
     }
@@ -851,19 +700,19 @@ sub run {
         say $JSON->encode( $json_output );
     }
 
-    if ( $self->save ) {
-        Zonemaster::Engine->save_cache( $self->save );
+    if ( $opt_save ) {
+        Zonemaster::Engine->save_cache( $opt_save );
     }
 
     return $EXIT_SUCCESS;
 }
 
 sub add_fake_delegation {
-    my ( $self, $domain ) = @_;
+    my ( $domain, @ns ) = @_;
     my @ns_with_no_ip;
     my %data;
 
-    foreach my $pair ( @{ $self->ns } ) {
+    foreach my $pair ( @ns ) {
         my ( $name, $ip ) = split( '/', $pair, 2 );
 
         if ( $pair =~ tr/\/// > 1 or not $name ) {
@@ -908,10 +757,10 @@ sub add_fake_delegation {
 }
 
 sub add_fake_ds {
-    my ( $self, $domain ) = @_;
+    my ( $domain, @ds ) = @_;
     my @data;
 
-    foreach my $str ( @{ $self->ds } ) {
+    foreach my $str ( @ds ) {
         my ( $tag, $algo, $type, $digest ) = split( /,/, $str );
         push @data, { keytag => $tag, algorithm => $algo, type => $type, digest => $digest };
     }

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -66,10 +66,9 @@ zonemaster-cli - run Zonemaster tests from the command line
 
 =head1 SYNOPSIS
 
-    zonemaster-cli zonemaster.net
-    zonemaster-cli --test=delegation --level=info --no-time zonemaster.net
-    zonemaster-cli --test=delegation/delegation01 --level=debug zonemaster.net
-    zonemaster-cli --list_tests
+    zonemaster-cli [--help | --version | --list-tests]
+    zonemaster-cli [OPTIONS] --dump-profile
+    zonemaster-cli [OPTIONS] DOMAINNAME
 
 =head1 DESCRIPTION
 
@@ -92,16 +91,22 @@ Print the available command line switches, then exit.
 
 =item B<--version>
 
-Print the versions of this program as well as the ones from the underlying 
-L<Zonemaster> test engine, then exit.
+Print version information and exit.
+
+The printed version numbers are the versions of this program as well as the ones from the underlying
+L<Zonemaster> test engine.
 
 =item B<--list-tests>
 
 Print all test cases listed in the test modules, then exit.
 
+=begin :man
+
 =item B<--dump-profile>
 
 Print the effective profile used in JSON format, then exit.
+
+=end :man
 
 =back
 
@@ -112,65 +117,72 @@ Print the effective profile used in JSON format, then exit.
 =item B<--test>=TESTCASE, B<--test>=TESTMODULE
 
 Limit the testing suite to run only the specified tests.
-This can be the name of a testing module, in which case all test cases from
+Can be specified multiple times.
+
+=for :man This can be the name of a testing module, in which case all test cases from
 that module will be run, or the name of a module followed by a slash and the
 name of a test case (test case identifier) in that module, or the name of the
 test case.
-Can be specified multiple times.
 This option is case-insensitive.
 
 =item B<--level>=LEVEL
 
-Specify the minimum level of a message to be printed. Messages with this level
+Specify the minimum level of a message to be printed.
+Default: NOTICE
+
+=for :man Messages with this level
 (or higher) will be printed. The levels are, from highest to lowest: 
 CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, DEBUG2 and DEBUG3.
 The lowest three levels (DEBUG) add a significant amount of messages to be shown.
 They reveal some of the internal workings of the test engine, and are probably 
 not useful for most users.
 
-Default: NOTICE
-
 =item B<--stop-level>=LEVEL
 
 Specify the minimum severity level after which the testing suite is terminated.
-The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
+
+=for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
 INFO, DEBUG, DEBUG2 and DEBUG3.
 
 =item B<--[no-]progress>
 
-Print an activity indicator ("spinner"). Useful to know that something is
-happening during a run.
-
+Print an activity indicator ("spinner").
 Default: on (if the process' standard output is a TTY)
+
+=for :man Useful to know that something is happening during a run.
 
 =item B<--[no-]ipv4>
 
 Allow the sending of IPv4 packets.
-
 Default: on
 
 =item B<--[no-]ipv6>
 
 Allow the sending of IPv6 packets.
-
 Default: on
 
 =item B<--sourceaddr4>=IPADDR
 
 Specify the source IPv4 address used to send queries.
-Setting an IPv4 address not correctly configured on a local network interface
+
+=for :man Setting an IPv4 address not correctly configured on a local network interface
 fails silently.
 
 =item B<--sourceaddr6>=IPADDR
 
 Specify the source IPv6 address used to send queries.
-Setting an IPv6 address not correctly configured on a local network interface
+
+=for :man Setting an IPv6 address not correctly configured on a local network interface
 fails silently.
+
+=begin :man
 
 =item B<--profile>=FILE
 
 Override the Zonemaster Engine default profile data with values from
 the given profile JSON file.
+
+=end :man
 
 =back
 
@@ -181,15 +193,14 @@ the given profile JSON file.
 =item B<--[no-]json>
 
 Print results as JSON instead of human language.
-
-Default: off
+Default: on
 
 =item B<--[no-]json-stream>
 
-Stream the results as JSON. Useful to follow the progress in a
-machine-readable way.
-
+Stream the results as JSON.
 Default: off
+
+=for :man Useful to follow the progress in a machine-readable way.
 
 =item B<--[no-]raw>
 
@@ -198,36 +209,40 @@ to human language.
 
 =item B<--locale>=LOCALE
 
-Specify which locale to be used by the translation system. If not given, the
+Specify which locale to be used by the translation system.
+
+=for :man If not given, the
 translation system itself will look at environment variables to try and guess.
 If the requested translation does not exist, it will fallback to the local
 locale, and if that doesn't exist either, to English.
 
+=begin :man
+
 =item B<--[no-]time>
 
 Print the timestamp for each message.
-
 Default: on
 
 =item B<--[no-]show-level>
 
 Print the severity level for each message.
-
 Default: on
 
 =item B<--[no-]show-module>
 
 Print the name of the module which produced the message.
-
 Default: off
 
 =item B<--[no-]show-testcase>
 
 Print the name of the test case (test case identifier) which produced the message.
-
 Default: off
 
+=end :man
+
 =back
+
+=begin :man
 
 =head2 Summary Options
 
@@ -237,7 +252,6 @@ Default: off
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
 level that were logged during the run.
-
 Default: off
 
 =item B<--nstimes>
@@ -248,7 +262,6 @@ name servers took to answer.
 =item B<--[no-]elapsed>
 
 Print elapsed time (in seconds) at end of a run.
-
 Default: off
 
 =back
@@ -313,6 +326,8 @@ Deprecated since v2023.1, use --no-raw instead.
 
 For streaming JSON output, include the translated message of the tag.
 
+=back
+
 =head2 Option Aliases
 
 These options are aliases for their namesakes spelled with dash C<-> instead of
@@ -337,6 +352,18 @@ underscore C<_>.
 =item B<--[no-]show_testcase>
 
 =back
+
+=end :man
+
+=head1 EXAMPLES
+
+    zonemaster-cli zonemaster.net
+
+    zonemaster-cli --test=delegation --level=info --no-time zonemaster.net
+
+    zonemaster-cli --test=delegation/delegation01 --level=debug zonemaster.net
+
+    zonemaster-cli --list_tests
 
 =head1 PROFILES
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -82,7 +82,9 @@ printed. See the available options below.
 
 =head1 OPTIONS
 
-=over
+=head2 General Options
+
+=over 4
 
 =item -h -? --usage --help
 
@@ -92,6 +94,30 @@ Print the available command line switches, then exit.
 
 Print the versions of this program as well as the ones from the underlying 
 L<Zonemaster> test engine, then exit.
+
+=item --list_tests, --list-tests
+
+Print all test cases listed in the test modules, then exit.
+
+=item --dump_profile, --dump-profile
+
+Print the effective profile used in JSON format, then exit.
+
+=back
+
+=head2 Testing Options
+
+=over 4
+
+=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
+
+Limit the testing suite to run only the specified tests.
+This can be the name of a testing module, in which case all test cases from
+that module will be run, or the name of a module followed by a slash and the
+name of a test case (test case identifier) in that module, or the name of the
+test case.
+Can be specified multiple times.
+This option is case-insensitive.
 
 =item --level=LEVEL
 
@@ -104,12 +130,53 @@ not useful for most users.
 
 Default: NOTICE
 
-=item --locale=LOCALE
+=item --stop_level=LEVEL, --stop-level=LEVEL
 
-Specify which locale to be used by the translation system. If not given, the
-translation system itself will look at environment variables to try and guess.
-If the requested translation does not exist, it will fallback to the local
-locale, and if that doesn't exist either, to English.
+Specify the minimum severity level after which the testing suite is terminated.
+The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
+INFO, DEBUG, DEBUG2 and DEBUG3.
+
+=item --[no-]progress
+
+Print an activity indicator ("spinner"). Useful to know that something is
+happening during a run.
+
+Default: on (if the process' standard output is a TTY)
+
+=item --[no-]ipv4
+
+Allow the sending of IPv4 packets.
+
+Default: on
+
+=item --[no-]ipv6
+
+Allow the sending of IPv6 packets.
+
+Default: on
+
+=item --sourceaddr4=IPADDR
+
+Specify the source IPv4 address used to send queries.
+Setting an IPv4 address not correctly configured on a local network interface
+fails silently.
+
+=item --sourceaddr6=IPADDR
+
+Specify the source IPv6 address used to send queries.
+Setting an IPv6 address not correctly configured on a local network interface
+fails silently.
+
+=item --profile=FILE
+
+Override the Zonemaster Engine default profile data with values from
+the given profile JSON file.
+
+=back
+
+=head2 Formatting Options
+
+=over 4
 
 =item --[no-]json
 
@@ -124,16 +191,17 @@ machine-readable way.
 
 Default: off
 
-=item --[no-]json_translate, --[no-]json-translate
-
-Deprecated since v2023.1, use --no-raw instead.
-
-For streaming JSON output, include the translated message of the tag.
-
 =item --[no-]raw
 
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
+
+=item --locale=LOCALE
+
+Specify which locale to be used by the translation system. If not given, the
+translation system itself will look at environment variables to try and guess.
+If the requested translation does not exist, it will fallback to the local
+locale, and if that doesn't exist either, to English.
 
 =item --[no-]time
 
@@ -159,6 +227,36 @@ Print the name of the test case (test case identifier) which produced the messag
 
 Default: off
 
+=back
+
+=head2 Summary Options
+
+=over 4
+
+=item --[no-]count
+
+Print a summary, at the end of a run, of the numbers of messages for each severity
+level that were logged during the run.
+
+Default: off
+
+=item --nstimes
+
+Print a summary, at the end of a run, of the times (in milliseconds) the zone's
+name servers took to answer.
+
+=item --[no-]elapsed
+
+Print elapsed time (in seconds) at end of a run.
+
+Default: off
+
+=back
+
+=head2 Undelegated Test Options
+
+=over 4
+
 =item --ns=NAME[/IP]
 
 Provide information about a nameserver, for undelegated tests. The argument
@@ -171,9 +269,22 @@ This switch can be given multiple times. As long as any of these switches
 are present, their aggregated content will be used as the
 entirety of the parent-side delegation information.
 
+=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
+
+Provide a DS record for undelegated testing (that is, a test where the
+delegating nameserver information is given via --ns switches). The four pieces
+of data (keytag, algorithm, type, digest) should be in the same format they would
+have in a zone file.
+
 =item --hints=FILENAME
 
 Name of a root hints file to override the defaults.
+
+=back
+
+=head2 Cache Options
+
+=over 4
 
 =item --save=FILENAME
 
@@ -186,94 +297,21 @@ Prime the DNS packet cache with the contents from the file with the given name
 before starting the testing suite. The format of the file should be from one
 produced by the --save switch.
 
-=item --[no-]ipv4
+=back
 
-Allow the sending of IPv4 packets.
+=head2 Deprecated Options
 
-Default: on
-
-=item --[no-]ipv6
-
-Allow the sending of IPv6 packets.
-
-Default: on
-
-=item --list_tests, --list-tests
-
-Print all test cases listed in the test modules, then exit.
-
-=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
-
-Limit the testing suite to run only the specified tests.
-This can be the name of a testing module, in which case all test cases from
-that module will be run, or the name of a module followed by a slash and the
-name of a test case (test case identifier) in that module, or the name of the
-test case.
-Can be specified multiple times.
-This option is case-insensitive.
-
-=item --stop_level=LEVEL, --stop-level=LEVEL
-
-Specify the minimum severity level after which the testing suite is terminated.
-The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
-INFO, DEBUG, DEBUG2 and DEBUG3.
-
-=item --profile=FILE
-
-Override the Zonemaster Engine default profile data with values from
-the given profile JSON file.
-
-=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
-
-Provide a DS record for undelegated testing (that is, a test where the
-delegating nameserver information is given via --ns switches). The four pieces
-of data (keytag, algorithm, type, digest) should be in the same format they would
-have in a zone file.
-
-=item --[no-]count
-
-Print a summary, at the end of a run, of the numbers of messages for each severity
-level that were logged during the run.
-
-Default: off
-
-=item --[no-]progress
-
-Print an activity indicator ("spinner"). Useful to know that something is
-happening during a run.
-
-Default: on (if the process' standard output is a TTY)
+=over 4
 
 =item --encoding=ENCODING
 
 Deprecated: Simply remove it from your usage. It is ignored.
 
-=item --nstimes
+=item --[no-]json_translate, --[no-]json-translate
 
-Print a summary, at the end of a run, of the times (in milliseconds) the zone's
-name servers took to answer.
+Deprecated since v2023.1, use --no-raw instead.
 
-=item --dump_profile, --dump-profile
-
-Print the effective profile used in JSON format, then exit.
-
-=item --sourceaddr4=IPADDR
-
-Specify the source IPv4 address used to send queries.
-Setting an IPv4 address not correctly configured on a local network interface
-fails silently.
-
-=item --sourceaddr6=IPADDR
-
-Specify the source IPv6 address used to send queries.
-Setting an IPv6 address not correctly configured on a local network interface
-fails silently.
-
-=item --[no-]elapsed
-
-Print elapsed time (in seconds) at end of a run.
-
-Default: off
+For streaming JSON output, include the translated message of the tag.
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -53,7 +53,7 @@ if ( defined $global_conf_file ) {
 }
 
 eval {
-    my $exitstatus = Zonemaster::CLI->new_with_options->run;
+    my $exitstatus = Zonemaster::CLI->run( @ARGV );
     exit $exitstatus;
 };
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -86,20 +86,20 @@ printed. See the available options below.
 
 =over 4
 
-=item -h -? --usage --help
+=item B<-h>, B<--help>, B<-?>, B<--usage>
 
 Print the available command line switches, then exit.
 
-=item --version
+=item B<--version>
 
 Print the versions of this program as well as the ones from the underlying 
 L<Zonemaster> test engine, then exit.
 
-=item --list_tests, --list-tests
+=item B<--list-tests>
 
 Print all test cases listed in the test modules, then exit.
 
-=item --dump_profile, --dump-profile
+=item B<--dump-profile>
 
 Print the effective profile used in JSON format, then exit.
 
@@ -109,7 +109,7 @@ Print the effective profile used in JSON format, then exit.
 
 =over 4
 
-=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
+=item B<--test>=TESTCASE, B<--test>=TESTMODULE
 
 Limit the testing suite to run only the specified tests.
 This can be the name of a testing module, in which case all test cases from
@@ -119,7 +119,7 @@ test case.
 Can be specified multiple times.
 This option is case-insensitive.
 
-=item --level=LEVEL
+=item B<--level>=LEVEL
 
 Specify the minimum level of a message to be printed. Messages with this level
 (or higher) will be printed. The levels are, from highest to lowest: 
@@ -130,44 +130,44 @@ not useful for most users.
 
 Default: NOTICE
 
-=item --stop_level=LEVEL, --stop-level=LEVEL
+=item B<--stop-level>=LEVEL
 
 Specify the minimum severity level after which the testing suite is terminated.
 The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
 INFO, DEBUG, DEBUG2 and DEBUG3.
 
-=item --[no-]progress
+=item B<--[no-]progress>
 
 Print an activity indicator ("spinner"). Useful to know that something is
 happening during a run.
 
 Default: on (if the process' standard output is a TTY)
 
-=item --[no-]ipv4
+=item B<--[no-]ipv4>
 
 Allow the sending of IPv4 packets.
 
 Default: on
 
-=item --[no-]ipv6
+=item B<--[no-]ipv6>
 
 Allow the sending of IPv6 packets.
 
 Default: on
 
-=item --sourceaddr4=IPADDR
+=item B<--sourceaddr4>=IPADDR
 
 Specify the source IPv4 address used to send queries.
 Setting an IPv4 address not correctly configured on a local network interface
 fails silently.
 
-=item --sourceaddr6=IPADDR
+=item B<--sourceaddr6>=IPADDR
 
 Specify the source IPv6 address used to send queries.
 Setting an IPv6 address not correctly configured on a local network interface
 fails silently.
 
-=item --profile=FILE
+=item B<--profile>=FILE
 
 Override the Zonemaster Engine default profile data with values from
 the given profile JSON file.
@@ -178,50 +178,50 @@ the given profile JSON file.
 
 =over 4
 
-=item --[no-]json
+=item B<--[no-]json>
 
 Print results as JSON instead of human language.
 
 Default: off
 
-=item --[no-]json_stream, --[no-]json-stream
+=item B<--[no-]json-stream>
 
 Stream the results as JSON. Useful to follow the progress in a
 machine-readable way.
 
 Default: off
 
-=item --[no-]raw
+=item B<--[no-]raw>
 
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
 
-=item --locale=LOCALE
+=item B<--locale>=LOCALE
 
 Specify which locale to be used by the translation system. If not given, the
 translation system itself will look at environment variables to try and guess.
 If the requested translation does not exist, it will fallback to the local
 locale, and if that doesn't exist either, to English.
 
-=item --[no-]time
+=item B<--[no-]time>
 
 Print the timestamp for each message.
 
 Default: on
 
-=item --[no-]show_level, --[no-]show-level
+=item B<--[no-]show-level>
 
 Print the severity level for each message.
 
 Default: on
 
-=item --[no-]show_module, --[no-]show-module
+=item B<--[no-]show-module>
 
 Print the name of the module which produced the message.
 
 Default: off
 
-=item --[no-]show_testcase, --[no-]show-testcase
+=item B<--[no-]show-testcase>
 
 Print the name of the test case (test case identifier) which produced the message.
 
@@ -233,19 +233,19 @@ Default: off
 
 =over 4
 
-=item --[no-]count
+=item B<--[no-]count>
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
 level that were logged during the run.
 
 Default: off
 
-=item --nstimes
+=item B<--nstimes>
 
 Print a summary, at the end of a run, of the times (in milliseconds) the zone's
 name servers took to answer.
 
-=item --[no-]elapsed
+=item B<--[no-]elapsed>
 
 Print elapsed time (in seconds) at end of a run.
 
@@ -257,7 +257,7 @@ Default: off
 
 =over 4
 
-=item --ns=NAME[/IP]
+=item B<--ns>=DOMAINNAME, B<--ns>=DOMAINNAME/IPADDR
 
 Provide information about a nameserver, for undelegated tests. The argument
 must be either: (i) a domain name and an IP address, separated by a single
@@ -269,14 +269,14 @@ This switch can be given multiple times. As long as any of these switches
 are present, their aggregated content will be used as the
 entirety of the parent-side delegation information.
 
-=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
+=item B<--ds>=KEYTAG,ALGORITHM,TYPE,DIGEST
 
 Provide a DS record for undelegated testing (that is, a test where the
 delegating nameserver information is given via --ns switches). The four pieces
 of data (keytag, algorithm, type, digest) should be in the same format they would
 have in a zone file.
 
-=item --hints=FILENAME
+=item B<--hints>=FILE
 
 Name of a root hints file to override the defaults.
 
@@ -286,12 +286,12 @@ Name of a root hints file to override the defaults.
 
 =over 4
 
-=item --save=FILENAME
+=item B<--save>=FILE
 
 Write the contents of the accumulated DNS packet cache to a file with the given name
 after the testing suite has finished running.
 
-=item --restore=FILENAME
+=item B<--restore>=FILE
 
 Prime the DNS packet cache with the contents from the file with the given name
 before starting the testing suite. The format of the file should be from one
@@ -303,15 +303,38 @@ produced by the --save switch.
 
 =over 4
 
-=item --encoding=ENCODING
+=item B<--encoding>=ENCODING
 
 Deprecated: Simply remove it from your usage. It is ignored.
 
-=item --[no-]json_translate, --[no-]json-translate
+=item B<--[no-]json-translate>
 
 Deprecated since v2023.1, use --no-raw instead.
 
 For streaming JSON output, include the translated message of the tag.
+
+=head2 Option Aliases
+
+These options are aliases for their namesakes spelled with dash C<-> instead of
+underscore C<_>.
+
+=over 4
+
+=item B<--list_tests>
+
+=item B<--dump_profile>
+
+=item B<--stop_level>=LEVEL
+
+=item B<--[no-]json_stream>
+
+=item B<--[no-]json_translate>
+
+=item B<--[no-]show_level>
+
+=item B<--[no-]show_module>
+
+=item B<--[no-]show_testcase>
 
 =back
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,18 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+# Ensure a recent version of Test::Pod
+my $min_tp = 1.22;
+eval "use Test::Pod $min_tp";
+plan skip_all => "Test::Pod $min_tp required for testing POD" if $@;
+
+my @poddirs;
+push @poddirs, ( -e 'lib' ? 'lib' : 'blib' );
+push @poddirs, 'script';
+
+all_pod_files_ok( all_pod_files( @poddirs ) );
+
+done_testing;

--- a/t/usage.t
+++ b/t/usage.t
@@ -537,6 +537,16 @@ do {
     check_usage_error 'Bad --hints (syntax)', [ '--hints', 't/usage.t', 'example.' ],
       qr{error loading hints file}i;
 
+    check_success '--help', ['--help'], qr{
+        ^Usage:$
+        .*
+        zonemaster-cli
+        .*
+        ^Options:$
+        .*
+        --help
+    }msx;
+
     check_success '--version', ['--version'], qr{
         ^\QZonemaster-CLI version\E .*
         ^\QZonemaster-Engine version\E .*

--- a/t/usage.wrapper.pl
+++ b/t/usage.wrapper.pl
@@ -10,6 +10,9 @@ use Zonemaster::Engine::Profile;
 
 use lib catfile( dirname( dirname( __FILE__ ) ), 'script' );
 
+# Help Zonemaster::CLI find zonemaster-cli in test context
+$Zonemaster::CLI::SCRIPT = catfile( dirname( dirname( __FILE__ ) ), 'script', 'zonemaster-cli' );
+
 # Parse command line options upto and including '--'.
 
 my $opt_record = 0;
@@ -60,7 +63,7 @@ do {
 
     # Run Zonemaster::CLI
     eval {
-        $EXIT_STATUS = Zonemaster::CLI->new_with_options->run;
+        $EXIT_STATUS = Zonemaster::CLI->run( @ARGV );
         1;
     } or do {
         print STDERR $@;


### PR DESCRIPTION
## Purpose

This PR makes `man zonemaster-cli` and `zonemaster-cli --help` be generated from the same source, ensuring they stay in sync.

The user documentation is greatly improved with regard to navigation, but very little is done to what you find when you get to the correct place. E.g. there are many cases of outdated facts and unclear language. I intend to make a follow-up PR making improvements in there areas.

## Context

Fixes #68. While this PR does not follow the issue to the letter, it does abide to it in spirit. The --help show a brief summary of the man page, not the full man page.

## Changes

Application:
* MooseX::Getopt is replaced with Getopt::Long and Pod::Usage.

Tests:
* A unit test is added to make sure --help work.
* A unit test is added to make sure all POD is syntactically correct.

Documentation:
* The --help output is now a brief summary of the full man page.
* Options are grouped into logical categories, making it much easier to navigate the options documentation.
* Options whose defaults were declared in the man page now also show their defaults in the --help text.
* Underscore aliases are moved to their own category and removed from the --help text.
* Deprecated options are moved to their own category and removed from the --help text.
* The synopsis section no longer doubles as an examples section. The old examples are moved to their own examples section.

## How to test this PR

* Unit tests should pass.
* Visually inspect the help text and man page of both this branch and the develop branch looking for regressions.
* Manually explore some edge cases like missing required arguments, unknown options, invalid arguments, or conflicting flags.