### PR TITLE
Organize --help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ To build your own Docker image, see the [Docker Image Creation] documentation.
 
 ## Documentation
 
-Other than the installation documentation, no specific documentation is needed.
-The [USING] document provides an overview on how to use the CLI.
+Run `zonemaster-cli --help` to get brief descriptions of a selection of the most
+important command line options.
+For complete reference documentation, see the manual page by running `man
+zonemaster-cli`.
+Additional end-user documentation is available in the [USING] document.
+
+When developing Zonemaster-CLI, refer to the [development documentation].
 
 
 ## Participation, Contact and Bug reporting
@@ -54,6 +59,7 @@ This is free software under a 2-clause BSD license. The full text of the license
 be found in the [LICENSE](LICENSE) file included in this respository.
 
 
+[Development documentation]:         https://github.com/zonemaster/zonemaster/blob/master/docs/public/development/cli.md
 [Docker Image Creation]:             https://github.com/zonemaster/zonemaster/blob/master/docs/internal/maintenance/ReleaseProcess-create-docker-image.md
 [Docker Hub]:                        https://hub.docker.com/u/zonemaster
 [Installation]:                      https://github.com/zonemaster/zonemaster/blob/master/docs/public/installation/zonemaster-cli.md

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -149,6 +149,9 @@ sub run {
 
     if ( $opt_help ) {
         my_pod2usage( verbosity => 1, output => \*STDOUT );
+        say "Severity levels from highest to lowest:";
+        say "  CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, DEBUG2, DEBUG3";
+
         return 0;
     }
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -66,10 +66,9 @@ zonemaster-cli - run Zonemaster tests from the command line
 
 =head1 SYNOPSIS
 
-    zonemaster-cli zonemaster.net
-    zonemaster-cli --test=delegation --level=info --no-time zonemaster.net
-    zonemaster-cli --test=delegation/delegation01 --level=debug zonemaster.net
-    zonemaster-cli --list_tests
+    zonemaster-cli [--help | --version | --list-tests]
+    zonemaster-cli [OPTIONS] --dump-profile
+    zonemaster-cli [OPTIONS] DOMAINNAME
 
 =head1 DESCRIPTION
 
@@ -88,7 +87,8 @@ printed. See the available options below.
 
 =item B<-h>, B<--help>
 
-Print the available command line switches, then exit.
+Print brief usage information and exit.
+(run `man zonemaster-cli` for the full manual page)
 
 =item B<--version>
 
@@ -134,6 +134,8 @@ The lowest three levels (DEBUG) add a significant amount of messages to be shown
 They reveal some of the internal workings of the test engine, and are probably
 not useful for most users.
 
+=begin :man
+
 =item B<--stop-level>=LEVEL
 
 Specify the minimum severity level after which the testing suite is terminated.
@@ -144,6 +146,8 @@ no matter what messages are emitted.
 
 =for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
 INFO, DEBUG, DEBUG2 and DEBUG3.
+
+=end :man
 
 =item B<--[no-]progress>
 
@@ -162,6 +166,8 @@ Default: on
 Allow the sending of IPv6 packets.
 Default: on
 
+=begin :man
+
 =item B<--sourceaddr4>=IPADDR
 
 Specify the source IPv4 address used to send queries.
@@ -175,6 +181,8 @@ Specify the source IPv6 address used to send queries.
 
 =for :man Setting an IPv6 address not correctly configured on a local network interface
 fails silently.
+
+=end :man
 
 =item B<--profile>=FILE
 
@@ -192,6 +200,8 @@ the given profile JSON file.
 Print results as JSON instead of human language.
 Default: off
 
+=begin :man
+
 =item B<--[no-]json-stream>
 
 Stream the results as JSON.
@@ -204,6 +214,8 @@ Default: off
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
 
+=end :man
+
 =item B<--locale>=LOCALE
 
 Specify which locale to be used by the translation system.
@@ -212,6 +224,8 @@ Specify which locale to be used by the translation system.
 translation system itself will look at environment variables to try and guess.
 If the requested translation does not exist, it will fallback to the local
 locale, and if that doesn't exist either, to English.
+
+=begin :man
 
 =item B<--[no-]time>
 
@@ -233,7 +247,11 @@ Default: off
 Print the name of the test case (test case identifier) which produced the message.
 Default: off
 
+=end :man
+
 =back
+
+=begin :man
 
 =head2 Summary Options
 
@@ -323,6 +341,8 @@ Deprecated since v2023.1, use --no-raw instead.
 
 =for :man For streaming JSON output, include the translated message of the tag.
 
+=back
+
 =head2 Option Aliases
 
 These options are provided for compatibility with older scripts.
@@ -353,6 +373,18 @@ underscore C<_>.
 =item B<--stop_level>=LEVEL
 
 =back
+
+=end :man
+
+=head1 EXAMPLES
+
+    zonemaster-cli zonemaster.net
+
+    zonemaster-cli --test=delegation --level=info --no-time zonemaster.net
+
+    zonemaster-cli --test=delegation/delegation01 --level=debug zonemaster.net
+
+    zonemaster-cli --list-tests
 
 =head1 PROFILES
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -156,30 +156,18 @@ Default: on (if the process' standard output is a TTY)
 
 =for :man Useful to know that something is happening during a run.
 
-=item B<--[no-]ipv4>
+=item B<--[no-]ipv4>, B<--[no-]ipv6>
 
-Allow the sending of IPv4 packets.
-Default: on
-
-=item B<--[no-]ipv6>
-
-Allow the sending of IPv6 packets.
-Default: on
+Enable or disable queries over IPv4 or IPv6.
+Default: both enabled
 
 =begin :man
 
-=item B<--sourceaddr4>=IPADDR
+=item B<--sourceaddr4>=IPADDR, B<--sourceaddr6>=IPADDR
 
-Specify the source IPv4 address used to send queries.
+Set IPv4 or IPv6 source address for DNS queries.
 
-=for :man Setting an IPv4 address not correctly configured on a local network interface
-fails silently.
-
-=item B<--sourceaddr6>=IPADDR
-
-Specify the source IPv6 address used to send queries.
-
-=for :man Setting an IPv6 address not correctly configured on a local network interface
+=for :man Setting an address not correctly configured on a local network interface
 fails silently.
 
 =end :man

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -373,7 +373,7 @@ underscore C<_>.
 
     zonemaster-cli --test=delegation --level=info --no-time zonemaster.net
 
-    zonemaster-cli --test=delegation/delegation01 --level=debug zonemaster.net
+    zonemaster-cli --test=delegation01 --level=debug zonemaster.net
 
     zonemaster-cli --list-tests
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -82,7 +82,9 @@ printed. See the available options below.
 
 =head1 OPTIONS
 
-=over
+=head2 Special Options
+
+=over 4
 
 =item -h -? --usage --help
 
@@ -94,6 +96,31 @@ Print version information and exit.
 
 =for :man The printed version numbers are the versions of this program as well as the ones from the underlying
 L<Zonemaster> test engine.
+
+=item --list_tests, --list-tests
+
+Print all test cases listed in the test modules, then exit.
+
+=item --dump_profile, --dump-profile
+
+Print the effective profile used in JSON format, then exit.
+
+=back
+
+=head2 Testing Options
+
+=over 4
+
+=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
+
+Limit the testing suite to run only the specified tests.
+Can be specified multiple times.
+
+=for :man This can be the name of a testing module, in which case all test cases from
+that module will be run, or the name of a module followed by a slash and the
+name of a test case (test case identifier) in that module, or the name of the
+test case.
+This option is case-insensitive.
 
 =item --level=LEVEL
 
@@ -107,14 +134,58 @@ The lowest three levels (DEBUG) add a significant amount of messages to be shown
 They reveal some of the internal workings of the test engine, and are probably
 not useful for most users.
 
-=item --locale=LOCALE
+=item --stop_level=LEVEL, --stop-level=LEVEL
 
-Specify which locale to be used by the translation system.
+Specify the minimum severity level after which the testing suite is terminated.
+(default: the empty string)
 
-=for :man If not given, the
-translation system itself will look at environment variables to try and guess.
-If the requested translation does not exist, it will fallback to the local
-locale, and if that doesn't exist either, to English.
+=for :man When set to the empty string, testing is allowed to complete normally
+no matter what messages are emitted.
+
+=for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
+INFO, DEBUG, DEBUG2 and DEBUG3.
+
+=item --[no-]progress
+
+Print an activity indicator ("spinner").
+Default: on (if the process' standard output is a TTY)
+
+=for :man Useful to know that something is happening during a run.
+
+=item --[no-]ipv4
+
+Allow the sending of IPv4 packets.
+Default: on
+
+=item --[no-]ipv6
+
+Allow the sending of IPv6 packets.
+Default: on
+
+=item --sourceaddr4=IPADDR
+
+Specify the source IPv4 address used to send queries.
+
+=for :man Setting an IPv4 address not correctly configured on a local network interface
+fails silently.
+
+=item --sourceaddr6=IPADDR
+
+Specify the source IPv6 address used to send queries.
+
+=for :man Setting an IPv6 address not correctly configured on a local network interface
+fails silently.
+
+=item --profile=FILE
+
+Override the Zonemaster Engine default profile data with values from
+the given profile JSON file.
+
+=back
+
+=head2 Formatting Options
+
+=over 4
 
 =item --[no-]json
 
@@ -128,16 +199,19 @@ Default: off
 
 =for :man Useful to follow the progress in a machine-readable way.
 
-=item --[no-]json_translate, --[no-]json-translate
-
-Deprecated since v2023.1, use --no-raw instead.
-
-=for :man For streaming JSON output, include the translated message of the tag.
-
 =item --[no-]raw
 
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
+
+=item --locale=LOCALE
+
+Specify which locale to be used by the translation system.
+
+=for :man If not given, the
+translation system itself will look at environment variables to try and guess.
+If the requested translation does not exist, it will fallback to the local
+locale, and if that doesn't exist either, to English.
 
 =item --[no-]time
 
@@ -159,6 +233,34 @@ Default: off
 Print the name of the test case (test case identifier) which produced the message.
 Default: off
 
+=back
+
+=head2 Summary Options
+
+=over 4
+
+=item --[no-]count
+
+Print a summary, at the end of a run, of the numbers of messages for each severity
+level that were logged during the run.
+Default: off
+
+=item --nstimes
+
+Print a summary, at the end of a run, of the times (in milliseconds) the zone's
+name servers took to answer.
+
+=item --[no-]elapsed
+
+Print elapsed time (in seconds) at end of a run.
+Default: off
+
+=back
+
+=head2 Undelegated Test Options
+
+=over 4
+
 =item --ns=NAME[/IP]
 
 Provide information about a nameserver, for undelegated tests.
@@ -173,9 +275,24 @@ overridden by --hints) and from which the results of that lookup will be used.
 are present, their aggregated content will be used as the
 entirety of the parent-side delegation information.
 
+=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
+
+Provide a DS record for undelegated testing (that is, a test where the
+delegating nameserver information is given via --ns switches).
+
+=for :man The four pieces
+of data (keytag, algorithm, type, digest) should be in the same format they would
+have in a zone file.
+
 =item --hints=FILENAME
 
 Name of a root hints file to override the defaults.
+
+=back
+
+=head2 Cache Options
+
+=over 4
 
 =item --save=FILENAME
 
@@ -190,100 +307,21 @@ before starting the testing suite.
 =for :man The format of the file should be from one produced by the --save
 switch.
 
-=item --[no-]ipv4
+=back
 
-Allow the sending of IPv4 packets.
-Default: on
+=head2 Deprecated Options
 
-=item --[no-]ipv6
-
-Allow the sending of IPv6 packets.
-Default: on
-
-=item --list_tests, --list-tests
-
-Print all test cases listed in the test modules, then exit.
-
-=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
-
-Limit the testing suite to run only the specified tests.
-Can be specified multiple times.
-
-=for :man This can be the name of a testing module, in which case all test cases from
-that module will be run, or the name of a module followed by a slash and the
-name of a test case (test case identifier) in that module, or the name of the
-test case.
-This option is case-insensitive.
-
-=item --stop_level=LEVEL, --stop-level=LEVEL
-
-Specify the minimum severity level after which the testing suite is terminated.
-(default: the empty string)
-
-=for :man When set to the empty string, testing is allowed to complete normally
-no matter what messages are emitted.
-
-=for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
-INFO, DEBUG, DEBUG2 and DEBUG3.
-
-=item --profile=FILE
-
-Override the Zonemaster Engine default profile data with values from
-the given profile JSON file.
-
-=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
-
-Provide a DS record for undelegated testing (that is, a test where the
-delegating nameserver information is given via --ns switches).
-
-=for :man The four pieces
-of data (keytag, algorithm, type, digest) should be in the same format they would
-have in a zone file.
-
-=item --[no-]count
-
-Print a summary, at the end of a run, of the numbers of messages for each severity
-level that were logged during the run.
-Default: off
-
-=item --[no-]progress
-
-Print an activity indicator ("spinner").
-Default: on (if the process' standard output is a TTY)
-
-=for :man Useful to know that something is happening during a run.
+=over 4
 
 =item --encoding=ENCODING
 
 Deprecated: Simply remove it from your usage. It is ignored.
 
-=item --nstimes
+=item --[no-]json_translate, --[no-]json-translate
 
-Print a summary, at the end of a run, of the times (in milliseconds) the zone's
-name servers took to answer.
+Deprecated since v2023.1, use --no-raw instead.
 
-=item --dump_profile, --dump-profile
-
-Print the effective profile used in JSON format, then exit.
-
-=item --sourceaddr4=IPADDR
-
-Specify the source IPv4 address used to send queries.
-
-=for :man Setting an IPv4 address not correctly configured on a local network interface
-fails silently.
-
-=item --sourceaddr6=IPADDR
-
-Specify the source IPv6 address used to send queries.
-
-=for :man Setting an IPv6 address not correctly configured on a local network interface
-fails silently.
-
-=item --[no-]elapsed
-
-Print elapsed time (in seconds) at end of a run.
-Default: off
+=for :man For streaming JSON output, include the translated message of the tag.
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -86,22 +86,22 @@ printed. See the available options below.
 
 =over 4
 
-=item -h -? --usage --help
+=item B<-h>, B<--help>
 
 Print the available command line switches, then exit.
 
-=item --version
+=item B<--version>
 
 Print version information and exit.
 
 =for :man The printed version numbers are the versions of this program as well as the ones from the underlying
 L<Zonemaster> test engine.
 
-=item --list_tests, --list-tests
+=item B<--list-tests>
 
 Print all test cases listed in the test modules, then exit.
 
-=item --dump_profile, --dump-profile
+=item B<--dump-profile>
 
 Print the effective profile used in JSON format, then exit.
 
@@ -111,7 +111,7 @@ Print the effective profile used in JSON format, then exit.
 
 =over 4
 
-=item --test=MODULE, --test=MODULE/TESTCASE, --test=TESTCASE
+=item B<--test>=TESTCASE, B<--test>=TESTMODULE
 
 Limit the testing suite to run only the specified tests.
 Can be specified multiple times.
@@ -122,7 +122,7 @@ name of a test case (test case identifier) in that module, or the name of the
 test case.
 This option is case-insensitive.
 
-=item --level=LEVEL
+=item B<--level>=LEVEL
 
 Specify the minimum level of a message to be printed.
 Default: NOTICE
@@ -134,7 +134,7 @@ The lowest three levels (DEBUG) add a significant amount of messages to be shown
 They reveal some of the internal workings of the test engine, and are probably
 not useful for most users.
 
-=item --stop_level=LEVEL, --stop-level=LEVEL
+=item B<--stop-level>=LEVEL
 
 Specify the minimum severity level after which the testing suite is terminated.
 (default: the empty string)
@@ -145,38 +145,38 @@ no matter what messages are emitted.
 =for :man The levels are, from highest to lowest: CRITICAL, ERROR, WARNING, NOTICE,
 INFO, DEBUG, DEBUG2 and DEBUG3.
 
-=item --[no-]progress
+=item B<--[no-]progress>
 
 Print an activity indicator ("spinner").
 Default: on (if the process' standard output is a TTY)
 
 =for :man Useful to know that something is happening during a run.
 
-=item --[no-]ipv4
+=item B<--[no-]ipv4>
 
 Allow the sending of IPv4 packets.
 Default: on
 
-=item --[no-]ipv6
+=item B<--[no-]ipv6>
 
 Allow the sending of IPv6 packets.
 Default: on
 
-=item --sourceaddr4=IPADDR
+=item B<--sourceaddr4>=IPADDR
 
 Specify the source IPv4 address used to send queries.
 
 =for :man Setting an IPv4 address not correctly configured on a local network interface
 fails silently.
 
-=item --sourceaddr6=IPADDR
+=item B<--sourceaddr6>=IPADDR
 
 Specify the source IPv6 address used to send queries.
 
 =for :man Setting an IPv6 address not correctly configured on a local network interface
 fails silently.
 
-=item --profile=FILE
+=item B<--profile>=FILE
 
 Override the Zonemaster Engine default profile data with values from
 the given profile JSON file.
@@ -187,24 +187,24 @@ the given profile JSON file.
 
 =over 4
 
-=item --[no-]json
+=item B<--[no-]json>
 
 Print results as JSON instead of human language.
 Default: off
 
-=item --[no-]json_stream, --[no-]json-stream
+=item B<--[no-]json-stream>
 
 Stream the results as JSON.
 Default: off
 
 =for :man Useful to follow the progress in a machine-readable way.
 
-=item --[no-]raw
+=item B<--[no-]raw>
 
 Print messages as raw dumps (message identifiers) instead of translating them
 to human language.
 
-=item --locale=LOCALE
+=item B<--locale>=LOCALE
 
 Specify which locale to be used by the translation system.
 
@@ -213,22 +213,22 @@ translation system itself will look at environment variables to try and guess.
 If the requested translation does not exist, it will fallback to the local
 locale, and if that doesn't exist either, to English.
 
-=item --[no-]time
+=item B<--[no-]time>
 
 Print the timestamp for each message.
 Default: on
 
-=item --[no-]show_level, --[no-]show-level
+=item B<--[no-]show-level>
 
 Print the severity level for each message.
 Default: on
 
-=item --[no-]show_module, --[no-]show-module
+=item B<--[no-]show-module>
 
 Print the name of the module which produced the message.
 Default: off
 
-=item --[no-]show_testcase, --[no-]show-testcase
+=item B<--[no-]show-testcase>
 
 Print the name of the test case (test case identifier) which produced the message.
 Default: off
@@ -239,18 +239,18 @@ Default: off
 
 =over 4
 
-=item --[no-]count
+=item B<--[no-]count>
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
 level that were logged during the run.
 Default: off
 
-=item --nstimes
+=item B<--[no-]nstimes>
 
 Print a summary, at the end of a run, of the times (in milliseconds) the zone's
 name servers took to answer.
 
-=item --[no-]elapsed
+=item B<--[no-]elapsed>
 
 Print elapsed time (in seconds) at end of a run.
 Default: off
@@ -261,7 +261,7 @@ Default: off
 
 =over 4
 
-=item --ns=NAME[/IP]
+=item B<--ns>=DOMAINNAME, B<--ns>=DOMAINNAME/IPADDR
 
 Provide information about a nameserver, for undelegated tests.
 
@@ -275,7 +275,7 @@ overridden by --hints) and from which the results of that lookup will be used.
 are present, their aggregated content will be used as the
 entirety of the parent-side delegation information.
 
-=item --ds=KEYTAG,ALGORITHM,TYPE,DIGEST
+=item B<--ds>=KEYTAG,ALGORITHM,TYPE,DIGEST
 
 Provide a DS record for undelegated testing (that is, a test where the
 delegating nameserver information is given via --ns switches).
@@ -284,7 +284,7 @@ delegating nameserver information is given via --ns switches).
 of data (keytag, algorithm, type, digest) should be in the same format they would
 have in a zone file.
 
-=item --hints=FILENAME
+=item B<--hints>=FILE
 
 Name of a root hints file to override the defaults.
 
@@ -294,12 +294,12 @@ Name of a root hints file to override the defaults.
 
 =over 4
 
-=item --save=FILENAME
+=item B<--save>=FILE
 
 Write the contents of the accumulated DNS packet cache to a file with the given name
 after the testing suite has finished running.
 
-=item --restore=FILENAME
+=item B<--restore>=FILE
 
 Prime the DNS packet cache with the contents from the file with the given name
 before starting the testing suite.
@@ -313,15 +313,44 @@ switch.
 
 =over 4
 
-=item --encoding=ENCODING
+=item B<--encoding>=ENCODING
 
 Deprecated: Simply remove it from your usage. It is ignored.
 
-=item --[no-]json_translate, --[no-]json-translate
+=item B<--[no-]json-translate>
 
 Deprecated since v2023.1, use --no-raw instead.
 
 =for :man For streaming JSON output, include the translated message of the tag.
+
+=head2 Option Aliases
+
+These options are provided for compatibility with older scripts.
+The first two are aliases for C<--help>.
+The rest are aliases for their namesakes spelled with dash C<-> instead of
+underscore C<_>.
+
+=over 4
+
+=item B<-?>
+
+=item B<--usage>
+
+=item B<--dump_profile>
+
+=item B<--[no-]json_stream>
+
+=item B<--[no-]json_translate>
+
+=item B<--list_tests>
+
+=item B<--[no-]show_level>
+
+=item B<--[no-]show_module>
+
+=item B<--[no-]show_testcase>
+
+=item B<--stop_level>=LEVEL
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -115,6 +115,7 @@ Print the effective profile used in JSON format, then exit.
 
 Limit the testing suite to run only the specified tests.
 Can be specified multiple times.
+(default: all test cases)
 
 =for :man This can be the name of a testing module, in which case all test cases from
 that module will be run, or the name of a module followed by a slash and the
@@ -125,7 +126,7 @@ This option is case-insensitive.
 =item B<--level>=LEVEL
 
 Specify the minimum level of a message to be printed.
-Default: NOTICE
+(default: NOTICE)
 
 =for :man Messages with this level
 (or higher) will be printed. The levels are, from highest to lowest:
@@ -152,14 +153,14 @@ INFO, DEBUG, DEBUG2 and DEBUG3.
 =item B<--[no-]progress>
 
 Print an activity indicator ("spinner").
-Default: on (if the process' standard output is a TTY)
+(default: enabled if the process' standard output is a TTY)
 
 =for :man Useful to know that something is happening during a run.
 
 =item B<--[no-]ipv4>, B<--[no-]ipv6>
 
 Enable or disable queries over IPv4 or IPv6.
-Default: both enabled
+(default: both enabled)
 
 =begin :man
 
@@ -186,14 +187,14 @@ the given profile JSON file.
 =item B<--[no-]json>
 
 Print results as JSON instead of human language.
-Default: off
+(default: disabled)
 
 =begin :man
 
 =item B<--[no-]json-stream>
 
 Stream the results as JSON.
-Default: off
+(default: disabled)
 
 =for :man Useful to follow the progress in a machine-readable way.
 
@@ -207,6 +208,7 @@ to human language.
 =item B<--locale>=LOCALE
 
 Specify which locale to be used by the translation system.
+(default: system locale or English)
 
 =for :man If not given, the
 translation system itself will look at environment variables to try and guess.
@@ -218,22 +220,22 @@ locale, and if that doesn't exist either, to English.
 =item B<--[no-]time>
 
 Print the timestamp for each message.
-Default: on
+(default: enabled)
 
 =item B<--[no-]show-level>
 
 Print the severity level for each message.
-Default: on
+(default: enabled)
 
 =item B<--[no-]show-module>
 
 Print the name of the module which produced the message.
-Default: off
+(default: disabled)
 
 =item B<--[no-]show-testcase>
 
 Print the name of the test case (test case identifier) which produced the message.
-Default: off
+(default: disabled)
 
 =end :man
 
@@ -249,17 +251,18 @@ Default: off
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
 level that were logged during the run.
-Default: off
+(default: disabled)
 
 =item B<--[no-]nstimes>
 
 Print a summary, at the end of a run, of the times (in milliseconds) the zone's
 name servers took to answer.
+(default: disabled)
 
 =item B<--[no-]elapsed>
 
 Print elapsed time (in seconds) at end of a run.
-Default: off
+(default: disabled)
 
 =back
 


### PR DESCRIPTION
## Purpose

Make the --help text more focused and organized.

## Context

* Because much of the documentation for CLI lives in the zonemaster/zonemaster repository, there's a dual PR in that repository. zonemaster/zonemaster#1309.
* This is a followup to #371 and includes those commits. It also includes the commits of #395 which fixes a bug introduced in the former.
* I've tried to keep this PR focused on structure and make as few changes as possible to the actual language. I have a lot of improvements in mind for that as well, but I'm saving those for one or more followup PRs for the next release.

## Changes

* Group options for easier navigation.
* Limit the contents and clutter of the --help output, but make sure to point to the man page.
* Include list of severity levels in --help output again (after removal in #371).
* Update default value declarations in --help output.
* Make default value declarations clearer and add missing ones.

## How to test this PR

Run `zonemaster-cli --help` and `man zonemaster-cli` and make sure they're visually alright.