### PR TITLE
Disable failing tests for now

### DIFF
--- a/t/usage.t
+++ b/t/usage.t
@@ -556,13 +556,17 @@ do {
         basic01
     }msx;
 
-    check_success '--dump-profile', ['--dump-profile'], qr{
-        "no_network"
-    }msx;
+  SKIP: {
+        skip 'test that hang on FreeBSD (FIXME, see #388)', 2;
 
-    check_success '--dump_profile', ['--dump_profile'], qr{
-        "no_network"
-    }msx;
+        check_success '--dump-profile', ['--dump-profile'], qr{
+            "no_network"
+        }msx;
+
+        check_success '--dump_profile', ['--dump_profile'], qr{
+            "no_network"
+        }msx;
+    };
 
     check_success 'override profile', [ '--dump-profile', '--profile=t/usage.profile' ], sub {
         my ( $profile ) = parse_json_stream( $_[0] );


### PR DESCRIPTION
## Purpose

This PR disables a couple of unit tests that hang on FreeBSD.

## Context

The problem was reported in #388.
Until #388 is fixed we can't rely on the automatic tests for the `--dump-profile` option.

## Changes

Two tests in t/usage.t are skipped (on all OSes)

## How to test this PR

The `t/usage.t` test should terminate successfully on FreeBSD.