### PR TITLE
Cleanup of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ addons:
     - libtool
     - m4
       # From Zonemaster CLI installation instruction for Ubuntu
-    # libmoosex-getopt-perl, see cpan-install below
     # libmodule-install-perl, see cpan-install below
     - libtry-tiny-perl
 


### PR DESCRIPTION
## Purpose

This PR just removes deprecated comment not relevant anymore. Does not affect anything.

Moose is not used in CLI anymore.

## How to test this PR

Review.
