### PR TITLE
Write “AS” in uppercase in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zonemaster/engine:local as build
+FROM zonemaster/engine:local AS build
 
 RUN apk add --no-cache \
     make \


### PR DESCRIPTION
## Purpose

This PR fixes a warning that appeared when running `docker build` on my test system (Rocky Linux 9):

```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

## Context

Release testing for 2024.2.

## Changes

- Write “FROM … AS” instead of “FROM … as” in the Dockerfile.

## How to test this PR

Build the container for `zonemaster-cli` according to the [documented procedure](https://github.com/zonemaster/zonemaster/blob/develop/docs/internal/maintenance/ReleaseProcess-create-docker-image.md). No warning should appear. (Although one should also check if the warning is generated by reverting this change.)