### PR TITLE
Provide more useful link in man page

### DIFF
--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -212,8 +212,8 @@ Specify which locale to be used by the translation system.
 
 =for :man If not given, the
 translation system itself will look at environment variables to try and guess.
-If the requested translation does not exist, it will fallback to the local
-locale, and if that doesn't exist either, to English.
+If the requested translation does not exist, it will fall back to the local
+locale, and if that does not exist either, to English.
 
 =begin :man
 
@@ -384,7 +384,7 @@ guided by a profile.
 Zonemaster Engine has a default profile with sensible defaults.
 Zonemaster CLI allows users to override the default profile data with
 values from a profile JSON file with the C<--profile> option.
-For details on profiles and how they're respresented in files, see
+For details on profiles and how they are respresented in files, see
 L<Zonemaster::Engine::Profile>.
 
 =head1 CONFIGURATION
@@ -416,7 +416,8 @@ the loaded config files.
 
 =head1 SEE ALSO
 
-L<Zonemaster>
+More complete documentation on Zonemaster and its tests can be found on
+L<https://doc.zonemaster.net>.
 
 =head1 AUTHOR
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -384,7 +384,7 @@ guided by a profile.
 Zonemaster Engine has a default profile with sensible defaults.
 Zonemaster CLI allows users to override the default profile data with
 values from a profile JSON file with the C<--profile> option.
-For details on profiles and how they are respresented in files, see
+For details on profiles and how they are represented in files, see
 L<Zonemaster::Engine::Profile>.
 
 =head1 CONFIGURATION

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -72,7 +72,7 @@ zonemaster-cli - run Zonemaster tests from the command line
 
 =head1 DESCRIPTION
 
-L<zonemaster-cli> is a command-line interface to the L<Zonemaster> test engine.
+L<zonemaster-cli> is a command-line interface to the Zonemaster test engine.
 It takes instructions the user provides as command line arguments, transforms
 them into suitable API calls to the engine, runs the test suite and prints the
 resulting messages. By default, the messages will be translated by the engine's
@@ -95,7 +95,7 @@ Print brief usage information and exit.
 Print version information and exit.
 
 =for :man The printed version numbers are the versions of this program as well as the ones from the underlying
-L<Zonemaster> test engine.
+Zonemaster test engine.
 
 =item B<--list-tests>
 


### PR DESCRIPTION
## Purpose

This PR replaces the text in the “See also” section of the man page/POD documentation in the `zonemaster-cli` command line utility with some information that I deemed more useful.

The previous text had a link to a Perl package called Zonemaster. But no such package actually exists, so the link is broken. Also, it looks very awkward when reading the man page version of this documentation, because links like these cannot be clicked on and just appear as “Zonemaster”. So the whole section reads as “See also: Zonemaster” in the man page.

## Context

Release testing for 2024.2; PR #389.

## Changes

* Rewrite “See also” section;
* As a drive-by change, some minor edits (e.g. replacing contractions such as “they’re” with their fully expanded equivalents such as “they are”) and removal of one typo.

## How to test this PR

Run `perldoc -o man script/zonemaster-cli` from the root of the code repository and check for correct rendering of the “See also” section.
