### PR TITLE
Add Ukrainian (uk) translation

### DIFF
--- a/share/uk.po
+++ b/share/uk.po
@@ -1,0 +1,202 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 19:25+0300\n"
+"PO-Revision-Date: 2026-08-28 22:50+0300\n"
+"Last-Translator: kolatitov132@gmail.com\n"
+"Language-Team: Zonemaster Team\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#: ../lib/Zonemaster/CLI.pm:177
+#, perl-brace-format
+msgid ""
+"Warning: setting locale category LC_MESSAGES to {locale} failed -- is it "
+"installed on this system?"
+msgstr ""
+"Попередження: не вдалося встановити категорію локалі LC_MESSAGES на {locale} "
+"-- чи встановлена вона в цій системі?"
+
+#: ../lib/Zonemaster/CLI.pm:184
+#, perl-brace-format
+msgid ""
+"Warning: setting locale category LC_CTYPE to {locale} failed -- is it "
+"installed on this system?"
+msgstr ""
+"Попередження: не вдалося встановити категорію локалі LC_CTYPE на {locale} -- "
+"чи встановлена вона в цій системі?"
+
+#: ../lib/Zonemaster/CLI.pm:200
+msgid "Warning: deprecated --encoding, simply remove it from your usage."
+msgstr ""
+"Попередження: опція --encoding застаріла, просто приберіть її з використання."
+
+#: ../lib/Zonemaster/CLI.pm:204
+msgid "Error: --json-stream and --no-json cannot be used together."
+msgstr "Помилка: --json-stream та --no-json не можна використовувати разом."
+
+#: ../lib/Zonemaster/CLI.pm:210
+msgid ""
+"Warning: --json-translate has no effect without either --json or --json-"
+"stream."
+msgstr ""
+"Попередження: --json-translate не має жодного ефекту без --json або --json-"
+"stream."
+
+#: ../lib/Zonemaster/CLI.pm:214
+msgid "Warning: deprecated --json-translate, use --no-raw instead."
+msgstr ""
+"Попередження: опція --json-translate застаріла, використовуйте натомість --"
+"no-raw."
+
+#: ../lib/Zonemaster/CLI.pm:217
+msgid "Warning: deprecated --no-json-translate, use --raw instead."
+msgstr ""
+"Попередження: опція --no-json-translate застаріла, використовуйте натомість "
+"--raw."
+
+#: ../lib/Zonemaster/CLI.pm:233
+#, perl-brace-format
+msgid "Loading profile from {path}."
+msgstr "Завантаження профілю з {path}."
+
+#: ../lib/Zonemaster/CLI.pm:247
+#, perl-brace-format
+msgid "Error: invalid value for --sourceaddr4: {reason}"
+msgstr "Помилка: недійсне значення для --sourceaddr4: {reason}"
+
+#: ../lib/Zonemaster/CLI.pm:258
+#, perl-brace-format
+msgid "Error: invalid value for --sourceaddr6: {reason}"
+msgstr "Помилка: недійсне значення для --sourceaddr6: {reason}"
+
+#: ../lib/Zonemaster/CLI.pm:277
+#, perl-brace-format
+msgid "Error: unrecognized term '{term}' in --test."
+msgstr "Помилка: нерозпізнаний термін '{term}' у параметрі --test."
+
+#: ../lib/Zonemaster/CLI.pm:301
+#, perl-brace-format
+msgid "Failed to recognize stop level '{level}'."
+msgstr "Не вдалося розпізнати рівень зупинки '{level}'."
+
+#: ../lib/Zonemaster/CLI.pm:306
+msgid ""
+"--level must be one of CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, DEBUG2 "
+"or DEBUG3."
+msgstr ""
+"--level має бути одним із CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, "
+"DEBUG2 або DEBUG3."
+
+#: ../lib/Zonemaster/CLI.pm:434
+msgid ""
+"Only one domain can be given for testing. Did you forget to prepend an "
+"option with '--<OPTION>'?"
+msgstr ""
+"Для тестування можна вказати лише один домен. Можливо, ви забули додати "
+"префікс '--<ОПЦІЯ>'?"
+
+#: ../lib/Zonemaster/CLI.pm:438
+msgid "Must give the name of a domain to test."
+msgstr "Необхідно вказати ім'я домену для тестування."
+
+#: ../lib/Zonemaster/CLI.pm:483
+#, perl-brace-format
+msgid "Error loading hints file: {message}"
+msgstr "Помилка завантаження файлу підказок (hints): {message}"
+
+#: ../lib/Zonemaster/CLI.pm:513
+msgid "Seconds"
+msgstr "Секунди"
+
+#: ../lib/Zonemaster/CLI.pm:514 ../lib/Zonemaster/CLI.pm:611
+msgid "Level"
+msgstr "Рівень"
+
+#: ../lib/Zonemaster/CLI.pm:515
+msgid "Module"
+msgstr "Модуль"
+
+#: ../lib/Zonemaster/CLI.pm:516
+msgid "Testcase"
+msgstr "Тест"
+
+#: ../lib/Zonemaster/CLI.pm:517
+msgid "Message"
+msgstr "Повідомлення"
+
+#: ../lib/Zonemaster/CLI.pm:586
+msgid "Looks OK."
+msgstr "Виглядає добре."
+
+#: ../lib/Zonemaster/CLI.pm:613
+msgid "Number of log entries"
+msgstr "Кількість записів у журналі"
+
+#: ../lib/Zonemaster/CLI.pm:628
+msgid "Message tag"
+msgstr "Тег повідомлення"
+
+#: ../lib/Zonemaster/CLI.pm:630
+msgid "Count"
+msgstr "Кількість"
+
+#: ../lib/Zonemaster/CLI.pm:690
+msgid "Name servers"
+msgstr "Сервери імен"
+
+#: ../lib/Zonemaster/CLI.pm:718
+msgid "Child zone"
+msgstr "Дочірня зона"
+
+#: ../lib/Zonemaster/CLI.pm:719
+msgid "Parent zone"
+msgstr "Батьківська зона"
+
+#: ../lib/Zonemaster/CLI.pm:720
+msgid "Other"
+msgstr "Інше"
+
+#: ../lib/Zonemaster/CLI.pm:736
+msgid "Grand total"
+msgstr "Загалом"
+
+#: ../lib/Zonemaster/CLI.pm:786
+msgid "--ns must be a name or a name/ip pair."
+msgstr "--ns має бути іменем або парою ім'я/ip."
+
+#: ../lib/Zonemaster/CLI.pm:818
+msgid ""
+"--ds ds data must be in the form \"keytag,algorithm,type,digest\". E.g. "
+"space is not permitted anywhere in the string."
+msgstr ""
+"--ds дані ds мають бути у форматі \"keytag,algorithm,type,digest\". "
+"Наприклад, пробіли не допускаються в жодному місці рядка."
+
+#: ../lib/Zonemaster/CLI.pm:920
+msgid "DEBUG"
+msgstr "DEBUG"
+
+#: ../lib/Zonemaster/CLI.pm:923
+msgid "INFO"
+msgstr "ІНФО"
+
+#: ../lib/Zonemaster/CLI.pm:926
+msgid "NOTICE"
+msgstr "ПРИМІТКА"
+
+#: ../lib/Zonemaster/CLI.pm:929
+msgid "WARNING"
+msgstr "ПОПЕРЕДЖЕННЯ"
+
+#: ../lib/Zonemaster/CLI.pm:932
+msgid "ERROR"
+msgstr "ПОМИЛКА"
+
+#: ../lib/Zonemaster/CLI.pm:935
+msgid "CRITICAL"
+msgstr "КРИТИЧНО"


### PR DESCRIPTION
## Purpose

This PR adds full Ukrainian (uk) language support to the Zonemaster CLI.

## Context

Zonemaster currently lacks a Ukrainian translation. This contribution introduces the necessary translations to make the interface accessible to Ukrainian-speaking users.

## Changes

Added `share/uk.po` with translated strings.
